### PR TITLE
redirects: Add basic redirection rules from existing Help pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -140,6 +140,37 @@ const config = {
         darkTheme: darkCodeTheme,
       },
     }),
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        createRedirects(existingPath) {
+          const oldPaths = [
+            'bump-cli',
+            'continuous-integration',
+            'specifications-support',
+            'api-change-management',
+            'branching',
+            'references',
+            'markdown-support',
+            'custom-domains',
+            'meta-images',
+            'hubs',
+            'organizations',
+            'access-management',
+            'faq',
+          ];
+
+          return oldPaths.map(oldPath => {
+            if (existingPath.includes(oldPath.to || `/docs/${oldPath}`)) {
+              // Redirection de /oldPath vers /docs/oldPath
+              return existingPath.replace(oldPath.to || `/docs/${oldPath}`, oldPath.from || `/${oldPath}`);
+            }
+          }).filter(redirect => redirect !== undefined)[0];
+        },
+      },
+    ],
+  ],
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.2.0",
+    "@docusaurus/plugin-client-redirects": "^2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,6 +1331,21 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
+"@docusaurus/plugin-client-redirects@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.2.0.tgz#f6228e5b2852520e22e0f4b89f870431aa975a90"
+  integrity sha512-psBoWi+cbc2I+VPkKJlcZ12tRN3xiv22tnZfNKyMo18iSY8gr4B6Q0G2KZXGPgNGJ/6gq7ATfgDK6p9h9XRxMQ==
+  dependencies:
+    "@docusaurus/core" "2.2.0"
+    "@docusaurus/logger" "2.2.0"
+    "@docusaurus/utils" "2.2.0"
+    "@docusaurus/utils-common" "2.2.0"
+    "@docusaurus/utils-validation" "2.2.0"
+    eta "^1.12.3"
+    fs-extra "^10.1.0"
+    lodash "^4.17.21"
+    tslib "^2.4.0"
+
 "@docusaurus/plugin-content-blog@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz#dc55982e76771f4e678ac10e26d10e1da2011dc1"


### PR DESCRIPTION
This plugin usage is a minimal implementation of #1 (client-side
redirects) to be able to do redirection of old help pages paths.

⚠ However, it is important to note that redirects are done client side
which is not ideal for SEO purposes. ⚠