### PR TITLE
redirects: use netlify static routing redirect rules

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+https://help.bump.sh/* https://docs.bump.sh/help/:splat/ 301!

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,2 @@
 https://help.bump.sh/* https://docs.bump.sh/help/:splat/ 301!
+/ /help/ 302


### PR DESCRIPTION
This rule will redirect any help.bump.sh/* pages to the new hub
content domain docs.bump.sh/help/*. See [netlify documentation](https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file) for details about the syntax of the `_redirects` file.

Closes #1 