### PR TITLE
style: override content styles

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -63,10 +63,15 @@
 @import "variables.css";
 @import "fonts.css";
 @import "navigation.css";
+@import "markdown.css";
 
 body {
   color: var(--text-color);
   font-family: var(--font-family);
   font-size: 0.9rem;
   font-weight: var(--font-weight-normal);
+}
+
+.container {
+  margin: var(--spacing-6) var(--spacing-12);
 }

--- a/src/css/markdown.css
+++ b/src/css/markdown.css
@@ -1,0 +1,49 @@
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4,
+.markdown h5,
+.markdown h6 {
+  font-family: var(--font-family);
+  font-weight: 400;
+}
+
+.markdown h1 {
+  font-size: 2rem;
+}
+
+.markdown h2 {
+  font-size: 1.75rem;
+}
+
+.markdown h3 {
+  font-size: 1.5rem;
+}
+
+.markdown h4 {
+  font-size: 1.25rem;
+}
+
+.markdown h5 {
+  font-size: 1.125rem;
+  font-weight: var(--font-weight-bold);
+}
+
+.markdown h6 {
+  font-weight: 1rem;
+  font-weight: var(--font-weight-bold);
+}
+
+.markdown code {
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-small);
+  font-size: 0.75rem;
+}
+
+.markdown strong {
+  font-weight: var(--font-weight-bold);
+}
+
+.pagination-nav__label {
+  font-weight: var(--font-weight-normal);
+}

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -2,9 +2,12 @@
   --brand-primary: var(--blue-60);
   --text-color: var(--gray-70);
   --link-color-hover: var(--gray-50);
+  --border-color: var(--gray-20);
+  --border-radius-small: 2px;
 }
 
 [data-theme='dark'] {
   --text-color: var(--gray-20);
   --link-color-hover: var(--gray-40);
+  --border-color: var(--slate-80);
 }


### PR DESCRIPTION
This makes the markdown content the same as in our docs.