### PR TITLE
fix: restore `.container` margins and apply changes to main content container

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -77,6 +77,6 @@ body {
   background-color: var(--bg-color);
 }
 
-.container {
-  margin: var(--spacing-6) var(--spacing-12);
+main {
+  padding: var(--spacing-6) var(--spacing-8);
 }


### PR DESCRIPTION
Because it broke the footer alignement 🤷‍♀️ :