### PR TITLE
core: don't use trailing slashes

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,4 @@
+/coucou /help/bump-cli
+
 https://help.bump.sh/* https://docs.bump.sh/help/:splat/ 301!
 / /help/ 302


### PR DESCRIPTION
This changes the docusaurus config to avoid adding trailing slashes to
routes. This is necessary only to be able to serve static files with
no extension, due to a bug in docusaurus...

https://github.com/facebook/docusaurus/issues/6282