### PR TITLE
Specifications support page

### DIFF
--- a/docs/help/specifications-support/index.md
+++ b/docs/help/specifications-support/index.md
@@ -2,12 +2,6 @@
 
 Bump.sh supports the most popular specifications for REST APIs and Event-Driven APIs.
 
-```mdx-code-block
-import DocCardList from '@theme/DocCardList';
-
-<DocCardList />
-```
-
 - [OpenAPI Specification](help/specifications-support/openapi-support.md)
 - [AsyncAPI Specification](help/specifications-support/asyncapi-support.md)
 

--- a/docs/help/specifications-support/index.md
+++ b/docs/help/specifications-support/index.md
@@ -1,0 +1,8 @@
+# Specifications Support
+
+Bump.sh supports the most popular specifications for REST APIs and Event-Driven APIs.
+
+- [OpenAPI Specification](help/specifications-support/openapi-support.md)
+- [AsyncAPI Specification](help/specifications-support/asyncapi-support.md)
+
+We do plan to support more specifications in the future. If there is one specifically you're looking for, feel free to contact us!

--- a/docs/help/specifications-support/index.md
+++ b/docs/help/specifications-support/index.md
@@ -2,6 +2,12 @@
 
 Bump.sh supports the most popular specifications for REST APIs and Event-Driven APIs.
 
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```
+
 - [OpenAPI Specification](help/specifications-support/openapi-support.md)
 - [AsyncAPI Specification](help/specifications-support/asyncapi-support.md)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -39,6 +39,7 @@ const sidebars = {
       {
         type: 'category',
         label: 'Specifications Support',
+        link: {type: 'doc', id: 'help/specifications-support/index'},
         collapsible: false,
         collapsed: false,
         items: [


### PR DESCRIPTION
- added a new home page for the specifications supported
- updated to sidebar to make the "specifications support" clickable, pointing to this page

Suggestion:
- would love to transform the bullet points into clickable cards.
- please review wording (I used "REST APIs" for instance, not sure of this)