### PR TITLE
Update on main page

### DIFF
--- a/docs/help/doc-topics.md
+++ b/docs/help/doc-topics.md
@@ -1,0 +1,25 @@
+# Documentation topics
+
+Creating good API documentation requires giving users context and guides. As most of the specifications don't permit to add generic content, we have created a custom property. Setting the `x-topics` property at the root of your documentation specification will let you add some content sections at the beginning of your documentation.
+
+|Property|Description|
+|---|---|
+|title|Topic title as it will appear in the navigation bar and in the content section.|
+|content|The topic content. Markdown is fully supported here.|
+|example|Will appear in the examples section, if activated. Markdown is fully supported here.|
+
+Example:
+
+```yaml
+x-topics:
+  - title: Getting started
+    content: Before using the API you need to get an API key by sending us an email.
+  - title: Authentication
+    content: Send the `X-API-KEY` header with all your requests.
+    example: |
+      ```
+      $ curl \
+        -X POST https://api.example.com/endpoint/ \
+        -H "X-API-KEY: XXXXXX" \
+      ```
+```

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -7,17 +7,16 @@ sidebar_label: Home
 
 Learn how to get the most of Bump.sh for your API ecosystem.
 
-- [Getting started](help/intro.md) (Learn about Bump.sh, how to deploy your first specification file and explore the possibilities)
-- [Specification support](help/specifications-support/openapi-support.md) (Which and how specifications are supported)
-- [Changelog](help/api-change-management/index.md) (Never miss any changes of your API, check them with the diff)
+- [Getting started](help/intro.md) -- Learn about Bump.sh, how to deploy your first specification file and explore the possibilities.
+- [Specification support](help/specifications-support/openapi-support.md) -- Which and how specifications are supported.
+- [Change Management](help/api-change-management/index.md) -- Never miss any changes of your API, check them with the diff.
 
 ## Manage your documentation and access
-- [Hubs](help/hubs.md) (Create groups of documentation)
-- [Organizations](help/organizations/index.md) (Invite teammates or partners to your ecosystem)
-- [Access Management](help/access-management.md) (Setup who can access what in your hubs and docs)
+- [Hubs](help/hubs.md) -- Create groups of documentation.
+- [Access Management](help/access-management.md) -- Setup who can access what in your hubs and docs.
+- [Organizations](help/organizations/index.md) -- Invite teammates or partners to your ecosystem.
 
 ## Customization
-- [Custom domain](help/custom-domains.md) (Host your documentation under your own domain)
-- [Branching](help/branching.md) (Switch between versions of a doc)
-- [Markdown Support](help/specifications-support/markdown-support.md) (Add context and information to your specification files)
-- [Meta images](help/meta-images.md) (Share docs links on your social medias)
+- [Custom domain](help/custom-domains.md) -- Host your documentation under your own domain.
+- [Documentation Topics](help/doc-topics.md) -- Add context and information to your specification files.
+- [Meta images](help/meta-images.md) -- Share docs links on your social medias.

--- a/docs/help/specifications-support/asyncapi-support.md
+++ b/docs/help/specifications-support/asyncapi-support.md
@@ -28,7 +28,7 @@ We support AsyncAPI `securitySchemes` property with these authentication types:
 - `oauth2`
 - `openIdConnect`
 
-We do not support `X509`, `symmetricEncryption`, `asymmetricEncryption`, `plain`, `scramSha256`, `scramSha512` nor `gssapi.` To describe these authentication types, please use our [custom `x-topics` property](https://help.bump.sh/markdown-support#adding-topics-to-your-documentation) for now.
+We do not support `X509`, `symmetricEncryption`, `asymmetricEncryption`, `plain`, `scramSha256`, `scramSha512` nor `gssapi.` To describe these authentication types, please use our [custom `x-topics` property](help/doc-topics.md) for now.
 
 ## readOnly and writeOnly properties
 

--- a/docs/help/specifications-support/asyncapi-support.md
+++ b/docs/help/specifications-support/asyncapi-support.md
@@ -59,5 +59,5 @@ Thus, it becomes easy to use the same Schema Object in different context, for ex
 
 ## Add topics to your documentation
 
-As this is not supported by AsyncAPI, we created a custom property to enrich your documentation. Find out more in our [dedicated section](https://help.bump.sh/markdown-support#adding-topics-to-your-documentation).
+As this is not supported by AsyncAPI, we created a custom property to enrich your documentation. Find out more in our [dedicated section](help/doc-topics.md).
 

--- a/docs/help/specifications-support/markdown-support.md
+++ b/docs/help/specifications-support/markdown-support.md
@@ -92,4 +92,4 @@ paths:
 
 With files `docs/introduction.md`, `docs/getting-started.md`, `docs/use-cases.md` and `docs/use-cases-examples.md` right next to your contract document, you will be able to generate a comprehensive API documentation with nicely formatted content for your users.
 
-It's a great way to include “Topic” sections with handwritten content before the documentation of endpoints/webhooks (or channels in case of an [AsyncAPI](https://www.asyncapi.com/) contract) in dedicated Markdown files. Thanks to the `x-topics` top-level property in your contract as [explained in the dedicated help page](help/specifications-support/openapi-support.md).
+It's a great way to include “Topic” sections with handwritten content before the documentation of endpoints/webhooks (or channels in case of an [AsyncAPI](https://www.asyncapi.com/) contract) in dedicated Markdown files. Thanks to the `x-topics` top-level property in your contract as [explained in the dedicated help page](help/doc-topics.md).

--- a/docs/help/specifications-support/markdown-support.md
+++ b/docs/help/specifications-support/markdown-support.md
@@ -93,30 +93,3 @@ paths:
 With files `docs/introduction.md`, `docs/getting-started.md`, `docs/use-cases.md` and `docs/use-cases-examples.md` right next to your contract document, you will be able to generate a comprehensive API documentation with nicely formatted content for your users.
 
 It's a great way to include “Topic” sections with handwritten content before the documentation of endpoints/webhooks (or channels in case of an [AsyncAPI](https://www.asyncapi.com/) contract) in dedicated Markdown files. Thanks to the `x-topics` top-level property in your contract as [explained in the dedicated help page](help/specifications-support/openapi-support.md).
-
-## Adding topics to your documentation
-
-Creating good API documentation requires giving users context and guides. As most of the specifications don't permit to add generic content, we have created a custom property. Setting the `x-topics` property at the root of your documentation specification will let you add some content sections at the beginning of your documentation.
-
-|Property|Description|
-|---|---|
-|title|Topic title as it will appear in the navigation bar and in the content section.|
-|content|The topic content. Markdown is fully supported here.|
-|example|Will appear in the examples section, if activated. Markdown is fully supported here.|
-
-Example:
-
-```yaml
-x-topics:
-  - title: Getting started
-    content: Before using the API you need to get an API key by sending us an email.
-  - title: Authentication
-    content: Send the `X-API-KEY` header with all your requests.
-    example: |
-      ```
-      $ curl \
-        -X POST https://api.example.com/endpoint/ \
-        -H "X-API-KEY: XXXXXX" \
-      ```
-```
-

--- a/docs/help/specifications-support/openapi-support.md
+++ b/docs/help/specifications-support/openapi-support.md
@@ -9,7 +9,7 @@ We support OpenAPI `securitySchemes` property (`securityDefinitions` with openAP
 - `oauth2`
 - `openIdConnect`
 
-We do not support `mutualTLS`. To describe a `mutualTLS` authentication method, please use the [`x-topics` property](https://help.bump.sh/markdown-support#adding-topics-to-your-documentation) for now.
+We do not support `mutualTLS`. To describe a `mutualTLS` authentication method, please use the [`x-topics` property](help/doc-topics.md) for now.
 
 ## readOnly and writeOnly properties
 

--- a/docs/help/specifications-support/openapi-support.md
+++ b/docs/help/specifications-support/openapi-support.md
@@ -40,5 +40,5 @@ Thus, it becomes easy to use the same Schema Object in different contexts, for e
 
 ## Add topics to your documentation
 
-As this is not supported by OpenAPI, we created a custom property to enrich your documentation. Find out more in our [dedicated section](https://help.bump.sh/markdown-support#adding-topics-to-your-documentation).
+As this is not supported by OpenAPI, we created a custom property to enrich your documentation. Find out more in our [dedicated section](help/doc-topics.md).
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -68,9 +68,8 @@ const sidebars = {
         ],
       },
       'help/branching',
-      'help/custom-domains',
-      'help/meta-images',
       'help/hubs',
+      'help/access-management',
       {
         type: 'category',
         label: 'Organizations',
@@ -79,7 +78,8 @@ const sidebars = {
         collapsed: true,
         items: ['help/organizations/single-sign-on-sso'],
       },
-      'help/access-management',
+      'help/custom-domains',
+      'help/meta-images',
       'help/faq',
     ]
 };


### PR DESCRIPTION
- quick update on home (modified wording, link and a few readability items) -- Not satisfied, need help here
- Splitted "topics" from the Markdown support page into a dedicated page ("doc-topics.md")
- modified the sidebar to group access related articles and customization options