### PR TITLE
Fix typo in data attribute

### DIFF
--- a/src/docusaurus-plugin-fathom/index.js
+++ b/src/docusaurus-plugin-fathom/index.js
@@ -20,7 +20,7 @@ module.exports = function pluginFathom(context, options) {
             tagName: "script",
             attributes: {
               src: "https://meadowlark.bump.sh/script.js",
-              dataSite: siteId,
+              "data-site": siteId,
               defer: true
             }
           },


### PR DESCRIPTION
Previous code was generating the following HTML code: `datasite="SITE_ID"`. We now correctly generate `data-site="SITE_ID"`.