### PR TITLE
Replace / by /help, and redirect until we have a real /

### DIFF
--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -1,5 +1,4 @@
 ---
-slug: /
 sidebar_label: Home
 ---
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,4 @@
 https://help.bump.sh/markdown-support https://docs.bump.sh/help/specifications-support/markdown-support/
 https://help.bump.sh/references https://docs.bump.sh/help/specifications-support/references/
-https://help.bump.sh/ https://docs.bump.sh/
 https://help.bump.sh/* https://docs.bump.sh/help/:splat/ 301!
 / /help/ 302


### PR DESCRIPTION
Redirecting a root custom domain to another doesn't work well (we get a Docusaurus error instead of being redirected).
With this change, we redirect everything (including /) on /help.