### PR TITLE
Fix footer images src

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,17 +150,17 @@ const config = {
     socialLinks: [
       {
         label: 'Github',
-        icon: 'img/footer/github.svg',
+        icon: '/img/footer/github.svg',
         to: 'https://github.com/bump-sh'
       },
       {
         label: 'Twitter',
-        icon: 'img/footer/twitter.svg',
+        icon: '/img/footer/twitter.svg',
         to: 'https://twitter.com/bump_hq'
       },
       {
         label: 'Linkedin',
-        icon: 'img/footer/linkedin.svg',
+        icon: '/img/footer/linkedin.svg',
         to: 'https://www.linkedin.com/company/bump-sh/'
       }
     ]


### PR DESCRIPTION
It was broken from the beginning for any page other than /, but it became visible because of the direct to /help.