### PR TITLE
Add links to bump.sh and developers.bump.sh

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,7 +63,18 @@ const config = {
           srcDark: 'img/bump-logo-wht.svg',
           href: '/help'
         },
-        items: [],
+        items: [
+          {
+            label: 'API reference',
+            to: 'https://developers.bump.sh',
+            position: 'right',
+          },
+          {
+            label: 'Bump.sh',
+            to: 'https://bump.sh',
+            position: 'right',
+          }
+        ],
       },
       footer: {
         style: 'dark',


### PR DESCRIPTION
This PR adds links to:
* https://bump.sh
* https://developers.bump.sh

Do you have any idea on other links we should display? Maybe we could add one pointing to https://github.com/bump-sh, with the GitHub icon? WDYT? Something else? 

This one follows the previously closed #33.

<img width="469" alt="Capture d’écran 2023-02-13 à 21 47 05" src="https://user-images.githubusercontent.com/30788/218571095-7a2f177b-c2d8-4f72-b8f3-5354e9b1f654.png">
