### PR TITLE
github-action: update latest changes from README

### DIFF
--- a/docs/help/continuous-integration/github-actions.md
+++ b/docs/help/continuous-integration/github-actions.md
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Deploy API documentation
-        uses: bump-sh/github-action@0.3
+        uses: bump-sh/github-action@v1
         with:
           doc: <BUMP_DOC_ID>
           token: ${{secrets.BUMP_TOKEN}}


### PR DESCRIPTION
We should probably find a way to sync the github-action repo README
with this help page, or simply write a different content here in the
help page?

(sync https://github.com/bump-sh/github-action/pull/366)