### PR TITLE
Nav: improve sidebar and add `doc-topic` page

### DIFF
--- a/docs/help/doc-topics.md
+++ b/docs/help/doc-topics.md
@@ -1,4 +1,4 @@
-# Documentation topics
+# Topics
 
 Creating good API documentation requires giving users context and guides. As most of the specifications don't permit to add generic content, we have created a custom property. Setting the `x-topics` property at the root of your documentation specification will let you add some content sections at the beginning of your documentation.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -71,8 +71,17 @@ const sidebars = {
         collapsed: true,
         items: ['organizations/single-sign-on-sso'],
       },
-      'custom-domains',
-      'meta-images',
+      {
+        type: 'category',
+        label: 'Documentation customization',
+        collapsible: true,
+        collapsed: true,
+        items: [
+          'doc-topics',
+          'custom-domains',
+          'meta-images'
+        ],
+      },
       'faq',
     ]
 };


### PR DESCRIPTION
The `doc-topic.md` page was not present in the sidebar.js file (making
it a page without sidebar, cf https://docs.bump.sh/help/doc-topics/).

I suggest to add a new sidebar category “Documentation
customization” (any other suggested wording by the reviewer will be
appreciate) and add this page inside it.