### PR TITLE
gh-action: upgrade examples with latest core gh actions

### DIFF
--- a/docs/help/continuous-integration/github-actions.md
+++ b/docs/help/continuous-integration/github-actions.md
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy API documentation
         uses: bump-sh/github-action@v1
         with:
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Comment pull request with API diff
         uses: bump-sh/github-action@v1
         with:
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy API documentation
         uses: bump-sh/github-action@v1
         with:
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Comment pull request with API diff
         uses: bump-sh/github-action@v1
         with:


### PR DESCRIPTION
Similarly to https://github.com/bump-sh/github-action/pull/398 we
upgrade the version of the core GH action used in our examples.