### PR TITLE
markdown support: add images section

### DIFF
--- a/docs/help/specifications-support/markdown-support.md
+++ b/docs/help/specifications-support/markdown-support.md
@@ -62,6 +62,16 @@ will render:
 this is an important information to **standout**
 :::
 
+## Images
+
+Use the following syntax to add images in your markdown
+```
+![Alt text](/path/to/image.jpg "Image title")
+```
+
+Note that even it's a best practice to always add an [alt text](https://en.wikipedia.org/wiki/Alt_attribute#Usage) for an image, the parameters `Alt text` and `"Image title"` are optional.
+
+
 ## Markdown files as an external reference
 
 Markdown files can be included as an [external reference](references.md) within your contract document with the $ref syntax `$ref: "./path/to/local-markdown.md"`. In the same way you can extract part of your contract (usually JSON schema of your models into dedicated `*.yaml` or `*.json` files), you can extract your markdown content into dedicated files too.

--- a/docs/help/specifications-support/markdown-support.md
+++ b/docs/help/specifications-support/markdown-support.md
@@ -69,7 +69,7 @@ Use the following syntax to add images in your markdown
 ![Alt text](/path/to/image.jpg "Image title")
 ```
 
-Note that even it's a best practice to always add an [alt text](https://en.wikipedia.org/wiki/Alt_attribute#Usage) for an image, the parameters `Alt text` and `"Image title"` are optional.
+Note that even if it's a best practice to always add an [alt text](https://en.wikipedia.org/wiki/Alt_attribute#Usage) for an image, the parameters `Alt text` and `"Image title"` are optional.
 
 ### Image sizing
 

--- a/docs/help/specifications-support/markdown-support.md
+++ b/docs/help/specifications-support/markdown-support.md
@@ -85,8 +85,8 @@ If you want to manually set the size of your image you can use Bump.sh `=dimensi
 
 for instance using `=100pxx50px` where 
 - `100` is the `height`
-- `px` the unit
-- `x` the separator
+- `px` the `unit`
+- `x` the `separator`
 - `50` the `width`
 - second `px` is `unit` again
 will output an image with 100 pixels height and 50 pixels width.

--- a/docs/help/specifications-support/markdown-support.md
+++ b/docs/help/specifications-support/markdown-support.md
@@ -118,15 +118,15 @@ You can use any of the following CSS length units as `unit`:
 - `pc` picas (1pc = 12 pt)
 
 **Relative units**:
-`em` relative to the font-size of the element (usually 1em = 16px)
-`ex` relative to the x-height of the current font (rarely used)  
-`ch` relative to the width of the "0" (Unicode U +0030) in the current font
-`rem` relative to font-size of the root element   
-`vw` relative to 1% of the width of the viewport*  
-`vh` relative to 1% of the height of the viewport*   
-`vmin` relative to 1% of viewport's* smaller dimension   
-`vmax` relative to 1% of viewport's* larger dimension  
-`%` relative to the parent element
+- `em` relative to the font-size of the element (usually 1em = 16px)
+- `ex` relative to the x-height of the current font (rarely used)  
+- `ch` relative to the width of the "0" (Unicode U +0030) in the current font
+- `rem` relative to font-size of the root element   
+- `vw` relative to 1% of the width of the viewport*  
+- `vh` relative to 1% of the height of the viewport*   
+- `vmin` relative to 1% of viewport's* smaller dimension   
+- `vmax` relative to 1% of viewport's* larger dimension  
+- `%` relative to the parent element
 
 ## Markdown files as an external reference
 

--- a/docs/help/specifications-support/markdown-support.md
+++ b/docs/help/specifications-support/markdown-support.md
@@ -75,10 +75,10 @@ Note that even it's a best practice to always add an [alt text](https://en.wikip
 
 If you want to manually set the size of your image you can use Bump.sh `=dimension` parameter just before the closing parenthesis as:
 ```
-![Alt text](/path/to/image.jpg "Image title" =100pxx50px)
+![Alt text](/path/to/image.jpg "Image title" =dimension)
 ```
 
-`dimension` uses the following syntax:
+`=dimension` uses the following syntax:
 ```
 =[height][unit]x[width][unit]
 ```

--- a/docs/help/specifications-support/markdown-support.md
+++ b/docs/help/specifications-support/markdown-support.md
@@ -80,14 +80,14 @@ If you want to manually set the size of your image you can use Bump.sh `=dimensi
 
 `=dimension` uses the following syntax:
 ```
-=[height][unit]x[width][unit]
+=[width][unit]x[height][unit]
 ```
 
 for instance using `=100pxx50px` where 
-- `100` is the `height`
+- `100` is the `width`
 - `px` the `unit`
 - `x` the `separator`
-- `50` the `width`
+- `50` the `height`
 - second `px` is `unit` again
 will output an image with 100 pixels height and 50 pixels width.
 

--- a/docs/help/specifications-support/markdown-support.md
+++ b/docs/help/specifications-support/markdown-support.md
@@ -71,6 +71,62 @@ Use the following syntax to add images in your markdown
 
 Note that even it's a best practice to always add an [alt text](https://en.wikipedia.org/wiki/Alt_attribute#Usage) for an image, the parameters `Alt text` and `"Image title"` are optional.
 
+### Image sizing
+
+If you want to manually set the size of your image you can use Bump.sh `=dimension` parameter just before the closing parenthesis as:
+```
+![Alt text](/path/to/image.jpg "Image title" =100pxx50px)
+```
+
+`dimension` uses the following syntax:
+```
+=[height][unit]x[width][unit]
+```
+
+for instance using `=100pxx50px` where 
+- `100` is the `height`
+- `px` the unit
+- `x` the separator
+- `50` the `width`
+- second `px` is `unit` again
+will output an image with 100 pixels height and 50 pixels width.
+
+At least one `height` *or* `width` parameter is mandatory, everything else being optional.
+
+```
+=100pxx50px   # with everything
+=100x50       # without unit
+=100          # without height (x separator not needed) and unit
+=100px        # without height
+=x50          # without width and unit
+=x50px        # without width
+```
+
+:::info
+- If you don't specify a `unit` it will default to pixel
+- If you don't specify `width` *or* `height`, the other value will be a ratio calculated from the original size of the image so it doesn't shrink
+:::
+
+You can use any of the following CSS length units as `unit`:
+
+**Absolute units**:
+- `cm` centimeters
+- `mm` millimeters
+- `in` inches (1in = 96px = 2.54cm)
+- `px` pixels (1px = 1/96th of 1in)
+- `pt` points (1pt = 1/72 of 1in)
+- `pc` picas (1pc = 12 pt)
+
+**Relative units**:
+`em` relative to the font-size of the element (usually 1em = 16px)
+`ex` relative to the x-height of the current font (rarely used)  
+`ch` relative to the width of the "0" (Unicode U +0030) in the current font
+`rem` relative to font-size of the root element   
+`vw` relative to 1% of the width of the viewport*  
+`vh` relative to 1% of the height of the viewport*   
+`vmin` relative to 1% of viewport's* smaller dimension   
+`vmax` relative to 1% of viewport's* larger dimension  
+`%` relative to the parent element
 
 ## Markdown files as an external reference
 


### PR DESCRIPTION
As mentionned in [this comment](https://docs.google.com/document/d/1Kk3OGx-DWg_7w5VdcTakj_6vlysblFFcJ9ja3ZxtUMs/edit?disco=AAAAwbTCQmg), Bump.sh supports images in markdown.

I've added a section that describes the usage and behaviour when adding images into documentations descriptions