### PR TITLE
fix: two product updates were inverted (wrong title <-> URL)

### DIFF
--- a/docs/product-updates/2022-12-07-improved-access-management.md
+++ b/docs/product-updates/2022-12-07-improved-access-management.md
@@ -1,25 +1,14 @@
 ---
-title: Enhanced Specifications Support
+title: Improved Access Management
 tags: [Improvement]
 ---
 
-Over the past weeks, we have considerably enhanced our support of the specifications.
+![improved-access-management.png](/files/changelog/improved-access-management.png)
 
-## minLength, maxLength and pattern
+Access management has been reshaped, thanks to extended tests and user feedback.
 
-Wherever you need to document restrictions on string fields, OpenAPI and AsyncAPI specifications rely on JSON Schema to support this.
-`minLength` and `maxLength`  are meant to constrain the length of a string.
-`pattern`  restrict the string to a specific Regular Expression (regex).
+Inviting external customers and partners to access internal APIs is now possible directly from the dashboard.
 
-Email addresses, IBANs and ZIP/Postal codes could be great examples of these features.
+From the dedicated section in your hub/documentation settings, you can quickly modify who has access to what. Open it to teammates of your organization, or invite external partners by email directly.
 
-
-![minlength-example.png](/files/changelog/minlength-example.png)
-
-
-## readOnly  and  writeOnly  properties
-
-JSON Schema allows defining a property as `readOnly`  or  `writeOnly`.
-Many examples can easily be imagined when used with AsyncAPI or OpenAPI : `readOnly`  timestamp, `writeOnly`  password, etc...
-
-Our [Help Center](https://docs.bump.sh/help/specifications-support/asyncapi-support/#readonly-and-writeonly-properties) shares more details on how Bump.sh works with this feature and a few examples.
+Password-protected level will stay available for a limited amount of time. More info can be found in our [help center](https://docs.bump.sh/help/access-management/).

--- a/docs/product-updates/2023-01-27-enhanced-specifications-support.md
+++ b/docs/product-updates/2023-01-27-enhanced-specifications-support.md
@@ -1,14 +1,25 @@
 ---
-title: Improved Access Management
+title: Enhanced Specifications Support
 tags: [Improvement]
 ---
 
-![improved-access-management.png](/files/changelog/improved-access-management.png)
+Over the past weeks, we have considerably enhanced our support of the specifications.
 
-Access management has been reshaped, thanks to extended tests and user feedback.
+## minLength, maxLength and pattern
 
-Inviting external customers and partners to access internal APIs is now possible directly from the dashboard.
+Wherever you need to document restrictions on string fields, OpenAPI and AsyncAPI specifications rely on JSON Schema to support this.
+`minLength` and `maxLength`  are meant to constrain the length of a string.
+`pattern`  restrict the string to a specific Regular Expression (regex).
 
-From the dedicated section in your hub/documentation settings, you can quickly modify who has access to what. Open it to teammates of your organization, or invite external partners by email directly.
+Email addresses, IBANs and ZIP/Postal codes could be great examples of these features.
 
-Password-protected level will stay available for a limited amount of time. More info can be found in our [help center](https://docs.bump.sh/help/access-management/).
+
+![minlength-example.png](/files/changelog/minlength-example.png)
+
+
+## readOnly  and  writeOnly  properties
+
+JSON Schema allows defining a property as `readOnly`  or  `writeOnly`.
+Many examples can easily be imagined when used with AsyncAPI or OpenAPI : `readOnly`  timestamp, `writeOnly`  password, etc...
+
+Our [Help Center](https://docs.bump.sh/help/specifications-support/asyncapi-support/#readonly-and-writeonly-properties) shares more details on how Bump.sh works with this feature and a few examples.


### PR DESCRIPTION
This commit makes sure to move content to the correct pages.