### PR TITLE
cli: add a paragraph about the folder deployment feature

### DIFF
--- a/docs/help/bump-cli.md
+++ b/docs/help/bump-cli.md
@@ -142,6 +142,44 @@ bump deploy path/to/file.json --doc my-documentation --branch staging
 You will need to pass your private documentation access token for this command to work. Either with the `--token` flag or via the `BUMP_TOKEN` environment variable. This token can be found from your documentation `settings > CI deployment`page.
 :::
 
+## Deploy a folder
+
+When using the [Hub](../hubs) feature on Bump.sh, you might want to deploy multiple api definition files in a single command. The `deploy` command described in the [previous paragraph](#deploy-a-file) accepts a folder path as argument to do just that:
+
+```shell
+bump deploy path/to/apis/ --hub my-hub
+```
+
+:::info
+You can find your own `my-hub` slug from your [hub settings](https://bump.sh/hubs).
+:::
+
+Take into account your file naming convention by using the `--filename-pattern <pattern>` option.
+
+Note that it can include `*` wildcard special character, `{slug}` filter that will extract your documentation's slug from the filename, as well as any other fixed characters.
+
+Here's a practical example. Suppose you have the following files in your `path/to/apis/` directory:
+
+```undefined
+path/to/apis
+└─ private-api-users-service.json
+└─ partner-api-payments-service.yml
+└─ public-api-contracts-service.yml
+└─ data.json
+└─ README.md
+```
+
+In order to deploy the 3 services api definition files from this folder (`private-api-users-service.json`, `partner-api-payments-service.yml` and `public-api-contracts-service.yml`). You can execute the following command:
+
+```shell
+bump deploy path/to/apis/ --hub my-hub --filename-pattern *-api-{slug}-service
+```
+
+
+:::caution
+You will need to pass your private hub access token for this command to work. Either with the `--token` flag or via the `BUMP_TOKEN` environment variable. This token can be found from your hub `settings > CI deployment` page.
+:::
+
 ## Compatible specification types
 
 We currently support [OpenAPI](https://github.com/OAI/OpenAPI-Specification) from 2.0 (called Swagger) to 3.1 and [AsyncAPI 2.x](https://www.asyncapi.com/docs/reference/specification/v2.5.0) specification file types. Both YAML or JSON file formats are accepted file inputs to the CLI.

--- a/docs/help/hubs.md
+++ b/docs/help/hubs.md
@@ -44,3 +44,15 @@ In this case, you have to provide the following parameters:
 - `--hub`:  the hub slug (or id)
 - `--token`: the hub token
 
+You can also combine this with the `--filename-pattern <pattern>` flag if you want to deploy multiple api definition files all at once.
+
+```shell
+bump deploy your/apis/folder/ --auto-create --filename-pattern *-{slug}-api --hub hub-slug-or-id --token hub-token
+```
+
+This command will search all files from the `your/apis/folder/` which matches the pattern `*-{slug}-api` and deploy each matching file to the corresponding `{slug}` documentation.
+
+For instance, a file called `private-payment-service-api.yml` will be deployed to a documentation on Bump.sh with the slug `payment-service`. Where as a file called `data.json` will not matched and be ignored by the command stated above.
+
+For more details about the folder deployment inside a Hub, please check the [Bump CLI related paragraph documentation page](../bump-cli#deploy-a-folder).
+


### PR DESCRIPTION
This feature was recently added in the [latest release of the
CLI](https://github.com/bump-sh/cli/releases/tag/v2.7.0) so we needed
to document its usage in the Bump CLI help page.

Let me know if something is unclear.