### PR TITLE
product-update: fix link and add link to Bump API

### DIFF
--- a/docs/product-updates/2023-06-16-api-branch-management.md
+++ b/docs/product-updates/2023-06-16-api-branch-management.md
@@ -6,11 +6,11 @@ image: /files/changelog/bump-sh-api-branch-management.png
 
 ![bump-sh-api-branch-management.png](/files/changelog/bump-sh-api-branch-management.png)
 
-Branch Management is now available from the API, making your API evolution workflows a whole lot smoother as an easy and effective way to manage your versions and optimizes how you deliver ephemeral or major ones, at hand (at least within our API).
+Branch Management is now available from the [Bump.sh API](https://developers.bump.sh/), making your API evolution workflows a whole lot smoother as an easy and effective way to manage your versions and optimizes how you deliver ephemeral or major ones, at hand (at least within our API).
 
 ### Let's explore how these new features simplify your API workflow
 
 1. [Branch creation](https://developers.bump.sh/operation/operation-post-docs-parameter-branches): Create a new branch effortlessly with a single API call, eliminating manual work.
-2. [List of Branches](https://developers.bump.sh/operation/operation-post-docs-parameter-branches): Obtain an overview of all API branches, facilitating efficient management and organization.
+2. [List of Branches](https://developers.bump.sh/operation/operation-get-docs-parameter-branches): Obtain an overview of all API branches, facilitating efficient management and organization.
 3. [Set Default Branch](https://developers.bump.sh/operation/operation-patch-docs-parameter-branches-parameter-set_default): Easily choose and showcase a default branch for up-to-date API documentation.
 4. [Delete Branch](https://developers.bump.sh/operation/operation-delete-docs-parameter-branches-parameter): Remove unnecessary branches to maintain a clean and organized development environment.


### PR DESCRIPTION
This commit fixes a link to the “list of branches” endpoint and also
adds an extra link in the introducing paragraph to our Api documentation.