### PR TITLE
Markdown: Image style

### DIFF
--- a/src/css/markdown.css
+++ b/src/css/markdown.css
@@ -44,6 +44,10 @@
   font-weight: var(--font-weight-bold);
 }
 
+.markdown img {
+  border-radius: var(--spacing-3);
+}
+
 .pagination-nav__label {
   font-weight: var(--font-weight-normal);
 }


### PR DESCRIPTION
This PR updates markdown image style by adding a rounded corner, as seen below:

**before**
<img width="1097" alt="Screenshot 2023-08-04 at 14 30 58" src="https://github.com/bump-sh/docs/assets/14966155/f1ceaa0f-21e1-40b5-9056-0c99aa02b42c">


**after**
<img width="1097" alt="Screenshot 2023-08-04 at 14 32 22" src="https://github.com/bump-sh/docs/assets/14966155/fb925049-f810-4455-83ce-e9cc1325621f">
