### PR TITLE
Adapt default label in group_operation_by

### DIFF
--- a/docs/help/specifications-support/openapi-support/name-and-sort-resources.md
+++ b/docs/help/specifications-support/openapi-support/name-and-sort-resources.md
@@ -1,7 +1,7 @@
 # Name and sort endpoints and webhooks
 
 In the Bump.sh console, if you click on any of your documentations and select **Customize UI** in the left menu, you can scroll down to **How to group operations?**. There are three options available:
-- `(default)`
+- `Automatically`
 The default behaviour of Bump.sh is automatic grouping based on the presence of a list of top-level `tags`. More on that in [the `Group by tags` section](#group-by-tag).
 - [`Group by tags`](#group-by-tag)
 - [`Group by path`](#group-by-path)


### PR DESCRIPTION
This label has been updated by https://github.com/bump-sh/bump/pull/3750, we forgot to update documentation.

Change is visible here:
https://deploy-preview-90--bump-content-hub.netlify.app/help/specifications-support/openapi-support/name-and-sort-resources/