### PR TITLE
Complete 'how to' guides with token

### DIFF
--- a/docs/help/getting-started/api-platform.md
+++ b/docs/help/getting-started/api-platform.md
@@ -6,7 +6,7 @@
 
 The following assumes your local machine is configured with PHP and API Platform.
 
-1. [Create and name](https://bump.sh/docs/new?utm_source=bump&utm_medium=content_hub&utm_campaign=getting_started) your first API documentation.
+1. [Create and name](https://bump.sh/docs/new?utm_source=bump&utm_medium=content_hub&utm_campaign=getting_started) your first API documentation. Then, retrieve the name and token of this documentation from the _CI deployment_ settings page.
 
 2. Install the Bump.sh CLI with [npm](https://docs.npmjs.com/cli/v9/configuring-npm/install?v=true) as below, or use [alternative options](../bump-cli.md), with
 
@@ -19,7 +19,9 @@ npm install -g bump-cli
 4. Deploy your doc to Bump.sh with
 
 ```bash
-bump deploy https://localhost/docs.json --doc my-documentation
+bump deploy https://localhost/docs.json \
+  --doc my-documentation-name \
+  --token my-documentation-token
 ```
 
 That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/index.md//#customization-options).

--- a/docs/help/getting-started/fastapi.md
+++ b/docs/help/getting-started/fastapi.md
@@ -6,7 +6,7 @@
 
 The following assumes your local machine is configured with Python and FastAPI, and that your main file is named `main.py`.
 
-1. [Create and name](https://bump.sh/docs/new?utm_source=bump&utm_medium=content_hub&utm_campaign=getting_started) your first API documentation.
+1. [Create and name](https://bump.sh/docs/new?utm_source=bump&utm_medium=content_hub&utm_campaign=getting_started) your first API documentation. Then, retrieve the name and token of this documentation from the _CI deployment_ settings page.
 
 2. Install the Bump.sh CLI with [npm](https://docs.npmjs.com/cli/v9/configuring-npm/install?v=true) as below, or use [alternative options](../bump-cli.md), with
 
@@ -14,7 +14,7 @@ The following assumes your local machine is configured with Python and FastAPI, 
 npm install -g bump-cli
 ```
 
-3. Launch your local server with 
+3. Launch your local server with
 
 ```bash
 uvicorn main:app --reload
@@ -25,7 +25,9 @@ Note: You might need, depending on how you usually run your Python commands, to 
 4. Deploy your doc to Bump.sh with
 
 ```bash
-bump deploy http://127.0.0.1:8000/openapi.json --doc my-documentation
+bump deploy http://127.0.0.1:8000/openapi.json \
+  --doc my-documentation-name \
+  --token my-documentation-token
 ```
 
 That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/index.md//#customization-options).


### PR DESCRIPTION
Using command `bump deploy` requires to use a parameter `token`.

This PR adapts sections How to start with ApiPlatform, and FastApi.

On the way back from ApiPlatform, I'd love to write more content about a better usecase to describe connexion between ApiPlatform and bump.sh,

This is a first step 😉