### PR TITLE
help: separate scroll for sidebar and content and remove footer

### DIFF
--- a/frontend/styles/components/toc.css
+++ b/frontend/styles/components/toc.css
@@ -4,7 +4,7 @@
   grid-column: 2 / -1;
   grid-row: 1 / 1000;
   position: sticky;
-  top: var(--spacing-30);
+  top: var(--spacing-8);
 }
 
 #markdown-toc,

--- a/frontend/styles/pages/help.css
+++ b/frontend/styles/pages/help.css
@@ -1,9 +1,13 @@
 .help {
+  height: 100dvh;
+  overflow: hidden;
+
   main {
     box-sizing: border-box;
     display: grid;
     gap: var(--gap-medium);
     justify-content: center;
+    overflow-y: scroll;
     padding: var(--spacing-8) var(--spacing-10);
     width: calc(100vw - var(--doc-sidebar-width));
 

--- a/src/_components/help/sidebar.css
+++ b/src/_components/help/sidebar.css
@@ -1,5 +1,6 @@
 side-bar {
   border-right: var(--border-default);
+  overflow-y: scroll;
   width: var(--doc-sidebar-width);
   z-index: 90;
 

--- a/src/_components/shared/footer.rb
+++ b/src/_components/shared/footer.rb
@@ -1,5 +1,10 @@
 class Shared::Footer < Bridgetown::Component
-  def initialize
+  def initialize(show:)
+    @show = show
     @site = Bridgetown::Current.site
+  end
+
+  def render?
+    @show
   end
 end

--- a/src/_layouts/default.erb
+++ b/src/_layouts/default.erb
@@ -9,6 +9,6 @@
 
     <%= yield %>
 
-    <%= render Shared::Footer.new %>
+    <%= render Shared::Footer.new(show: data.footer) %>
   </body>
 </html>

--- a/src/_layouts/help.erb
+++ b/src/_layouts/help.erb
@@ -1,5 +1,6 @@
 ---
 layout: default
+footer: false
 ---
 
 <%= render Help::Sidebar.new(metadata: site.metadata, resource: resource, page_list: collections.help.resources) %>


### PR DESCRIPTION
This PR allows the Help page sidebar and content to be scrolled separately by fixing a max-height.
It removes the footer that made the scrolling a bit awkward.

This is a first step to a seamless sidebar when navigating through the search.