### PR TITLE
guides: assign a default category

### DIFF
--- a/plugins/builders/guide_category.rb
+++ b/plugins/builders/guide_category.rb
@@ -1,0 +1,11 @@
+class Builders::GuideCategory < SiteBuilder
+  priority :highest
+
+  def build
+    generator do
+      site.collections.guides.resources.each { |guide|
+        guide.data.categories.unshift(guide.relative_path.to_s.split("/")[1].split("-").join(" ").capitalize)
+      }
+    end
+  end
+end

--- a/src/_guides/getting-started/api-platform.md
+++ b/src/_guides/getting-started/api-platform.md
@@ -1,6 +1,7 @@
 ---
 title: Deploying docs from API Platform
 authors: polo
+categories: ["test"]
 ---
 
 [API Platform](https://api-platform.com/) is an API-first PHP framework that allows you to create REST and GraphQL APIs using PHP classes, and automatically generates their documentation, based on the OpenAPI specification. If you are new to API Platform, check out [their getting started guide](https://api-platform.com/docs/distribution/).


### PR DESCRIPTION
This commit adds a builder that will set a category parent folder as a default category so we don't have to add it by hand.

![image](https://github.com/bump-sh/docs/assets/1301085/bcafa99c-d449-416b-a0b1-c435ade32c71)
