### PR TITLE
help: add anchor link to headings

### DIFF
--- a/frontend/javascript/controllers/copy_controller.js
+++ b/frontend/javascript/controllers/copy_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class Copy extends Controller {
+  copy(event) {
+    const link = event.target.getAttribute("href")
+    if (link) {
+      navigator.clipboard.writeText(window.location.href.split("#")[0] + link)
+    }
+  }
+}

--- a/frontend/styles/pages/help.css
+++ b/frontend/styles/pages/help.css
@@ -44,7 +44,7 @@
     }
   
     h1, h2, h3, h4 {
-      scroll-margin-top: var(--spacing-24);
+      scroll-margin-top: var(--spacing-8);
     }
 
     #markdown-toc {

--- a/frontend/styles/typography.css
+++ b/frontend/styles/typography.css
@@ -26,3 +26,23 @@ html {
 :where(strong) {
   font-weight: var(--font-weight-semibold);
 }
+
+h2, h3, h4 {
+  &[id] {
+    position: relative;
+
+    .heading-anchor {
+      bottom: 0.2em;
+      font-size: 0.75em;
+      font-weight: 500;
+      margin-left: var(--gap-xsmall);
+      opacity: 0;
+      position: absolute;
+      transition: opacity 0.3s;
+    }
+
+    &:hover .heading-anchor {
+      opacity: 1;
+    }
+  }
+}

--- a/plugins/builders/inspectors.rb
+++ b/plugins/builders/inspectors.rb
@@ -1,0 +1,15 @@
+class Builders::Inspectors < SiteBuilder
+  def build
+    inspect_html do |document|
+      document.query_selector_all("main h2[id], main h3[id], main h4[id]").each do |heading|
+        heading << document.create_text_node(" ")
+        heading << document.create_element(
+          "a", "#",
+          href: "##{heading[:id]}",
+          class: "heading-anchor",
+          "data-action": "copy#copy"
+        )
+      end
+    end
+  end
+end

--- a/src/_layouts/default.erb
+++ b/src/_layouts/default.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render "head", metadata: site.metadata, title: data.title %>
   </head>
-  <body class="<%= data.page_class %>" <% if data.sidebar %>data-controller="toggle"<% end %>>
+  <body class="<%= data.page_class %>"data-controller="copy <% if data.sidebar %>toggle<% end %>">
     <%# lit :bump_navbar, logo: relative_url('/images/bump-logo.svg') %>
     <%= render Shared::Navbar.new(metadata: site.metadata, resource: resource) %>
 


### PR DESCRIPTION
This PR adds a builder that automatically applies a link to content headings that can be copied on click.

![image](https://github.com/bump-sh/docs/assets/1301085/c7ab3f82-6d2d-4205-9711-653c1624667b)
