### PR TITLE
help: improve sidebar performances

### DIFF
--- a/plugins/builders/sidebar.rb
+++ b/plugins/builders/sidebar.rb
@@ -1,0 +1,25 @@
+class Builders::Sidebar < SiteBuilder
+  def build
+    generator do
+      site.data.help_sidebar = build_resources(@site.data.sidebar.help)
+    end
+  end
+
+  def build_resources(list)
+    if list.present?
+      list.map do |list_item|
+        if list_item.link.present?
+          resource = site.collections.help.resources.find do |page|
+            page.relative_url.end_with?("/help#{list_item.link}")
+          end
+        end
+        {
+          label: list_item.label,
+          icon: list_item.icon,
+          resource: resource,
+          items: list_item.items.present? && build_resources(list_item.items)
+        }
+      end
+    end
+  end
+end

--- a/src/_components/help/sidebar.erb
+++ b/src/_components/help/sidebar.erb
@@ -5,8 +5,8 @@
       Hide menu
     </button>
     <ul class="sidebar-list">
-      <% @site.data.sidebar.help.each do |page| %>
-        <%= render Help::Sidebar::Item.new(page: page, page_list: @page_list, resource: @resource) %>
+      <% @site.data.help_sidebar.each do |page| %>
+        <%= render Help::Sidebar::Item.new(page: page, current: @current) %>
       <% end %>
     </ul>
   </aside>

--- a/src/_components/help/sidebar.rb
+++ b/src/_components/help/sidebar.rb
@@ -1,8 +1,7 @@
 class Help::Sidebar < Bridgetown::Component
-  def initialize(metadata:, resource:, page_list:)
+  def initialize(metadata:, current:)
     @metadata = metadata
-    @resource = resource
-    @page_list = page_list
+    @current = current
     @site = Bridgetown::Current.site
   end
 end

--- a/src/_components/help/sidebar/item.css
+++ b/src/_components/help/sidebar/item.css
@@ -9,7 +9,7 @@ side-item {
     padding: var(--spacing-1) var(--spacing-3);
     text-decoration: none;
 
-    &:hover {
+    &:is(a):hover {
       color: var(--base-color);
     }
 

--- a/src/_components/help/sidebar/item.erb
+++ b/src/_components/help/sidebar/item.erb
@@ -1,20 +1,20 @@
 <side-item>
   <li>
-    <% if item_resource.present? %>
-      <a class="item" href="<%= item_resource.relative_url %>"<% if is_current? %> aria-current="true"<% end %>>
-        <%= svg "images/icons/#{@page.icon}.svg" if @page.icon.present? %>
-        <%= @page.label %>
+    <% if @resource.present? %>
+      <a class="item" href="<%= @resource.relative_url %>"<% if @is_current %> aria-current="true"<% end %>>
+        <%= svg "images/icons/#{@icon}.svg" if @icon.present? %>
+        <%= @label %>
       </a>
     <% else %>
-      <div class="item"<% if is_current? %> aria-current="true"<% end %>>
-        <%= svg "images/icons/#{@page.icon}.svg" if @page.icon.present? %>
-        <%= @page.label %>
+      <div class="item"<% if @is_current %> aria-current="true"<% end %>>
+        <%= svg "images/icons/#{@icon}.svg" if @icon.present? %>
+        <%= @label %>
       </div>
     <% end %>
-    <% if is_category? %>
+    <% if @items.present? %>
       <ul class="sidebar-sublist">
-        <% @page.items.each do |item| %>
-          <%= render Help::Sidebar::Item.new(page: item, page_list: @page_list, resource: @resource) %>
+        <% @items.each do |item| %>
+          <%= render Help::Sidebar::Item.new(page: item, current: @current) %>
         <% end %>
       </ul>
     <% end %>

--- a/src/_components/help/sidebar/item.rb
+++ b/src/_components/help/sidebar/item.rb
@@ -1,19 +1,11 @@
 class Help::Sidebar::Item < Bridgetown::Component
-  def initialize(page:, page_list:, resource:)
+  def initialize(page:, current:)
     @page = page
-    @page_list = page_list
-    @resource = resource
+    @current = current
+    @resource = @page[:resource]
+    @is_current = @resource.present? && @resource.path == @current.path
+    @icon = @page[:icon]
+    @label = @page[:label]
+    @items = @page[:items]
   end
-
-  def item_resource
-    @page_list.find { |page| page.relative_url.end_with?("/help#{@page.link}") } if @page.link.present?
-  end
-
-  def is_category?
-    @page.type == "category"
-  end
-
-  def is_current?
-    item_resource.present? && @resource.path == item_resource.path
-  end 
 end

--- a/src/_data/sidebar.yml
+++ b/src/_data/sidebar.yml
@@ -1,129 +1,93 @@
 help:
-  - type: page
-    label: Home
+  - label: Home
     link: /
     icon: home
-  - type: page
-    label: Quick Start
+  - label: Quick Start
     link: /quick-start/
     icon: zap
-  - type: page
-    label: Bump CLI
+  - label: Bump CLI
     link: /bump-cli/
     icon: terminal
-  - type: category
-    label: Continuous Integration
+  - label: Continuous Integration
     link: /continuous-integration/
     icon: iteration
     items:
-      - type: page
-        label: Github Action
+      - label: Github Action
         link: /continuous-integration/github-actions/
-  - type: page
-    label: Release Management
+  - label: Release Management
     link: /publish-documentation/release-management/
     icon: send
-  - type: category
-    label: API change management
+  - label: API change management
     link: /api-change-management/
     icon: bell-dot
     items:
-      - type: page
-        label: Webhooks
+      - label: Webhooks
         link: /api-change-management/webhooks/
-  - type: page
-    label: Branching
+  - label: Branching
     link: /branching/
     icon: branch
-  - type: category
-    label: Hubs
+  - label: Hubs
     link: /hubs/
     icon: hub
     items:
-      - type: page
-        label: Create and manage hubs
+      - label: Create and manage hubs
         link: /hubs/create-and-manage-hubs/
-      - type: page
-        label: Hub settings
+      - label: Hub settings
         link: /hubs/hub-settings/
-  - type: page
-    label: Access Management
+  - label: Access Management
     link: /access-management/
     icon: key
-  - type: category
-    label: Organizations
+  - label: Organizations
     link: /organizations/
     icon: org
     items:
-      - type: page
-        label: Create and manage organizations
+      - label: Create and manage organizations
         link: /organizations/create-and-manage-organizations/
-      - type: page
-        label: Organization Access Management
+      - label: Organization Access Management
         link: /organizations/organization-access-management/
-  - type: category
-    label: Documentation customization
+  - label: Documentation customization
     icon: sparkles
     items:
-      - type: page
-        label: Topics
+      - label: Topics
         link: /doc-topics/
-      - type: page
-        label: Custom domains
+      - label: Custom domains
         link: /custom-domains/
-      - type: page
-        label: Meta images
+      - label: Meta images
         link: /meta-images/
-      - type: page
-        label: Custom code samples
+      - label: Custom code samples
         link: /doc-code-samples/
-  - type: category
-    label: Account
+  - label: Account
     icon: user
     items:
-      - type: page
-        label: User account settings
+      - label: User account settings
         link: /account/user-account-settings/
-      - type: page
-        label: Billing
+      - label: Billing
         link: /account/billing/
-      - type: page
-        label: Github Student
+      - label: Github Student
         link: /account/github-student/
-  - type: category
-    label: Specification Support
+  - label: Specification Support
     link: /specification-support/
     icon: code-file
     items:
-      - type: category
-        label: OpenAPI support
+      - label: OpenAPI support
         link: /specification-support/openapi-support/
         items:
-          - type: page
-            label: Name and sort endpoints and webhooks
+          - label: Name and sort endpoints and webhooks
             link: /specification-support/openapi-support/name-and-sort-resources/
-          - type: page
-            label: Webhooks
+          - label: Webhooks
             link: /specification-support/openapi-support/webhooks/
-      - type: page
-        label: AsyncAPI support
+      - label: AsyncAPI support
         link: /specification-support/asyncapi-support/
-      - type: page
-        label: Markdown support
+      - label: Markdown support
         link: /specification-support/markdown-support/
-      - type: page
-        label: JSON Schema
+      - label: JSON Schema
         link: /specification-support/json-schema/
-      - type: page
-        label: Polymorphism
+      - label: Polymorphism
         link: /specification-support/polymorphism/
-      - type: page
-        label: References
+      - label: References
         link: /specification-support/references/
-      - type: page
-        label: Multiple servers
+      - label: Multiple servers
         link: /specification-support/multiple-servers/
-  - type: page
-    label: FAQ
+  - label: FAQ
     link: /faq/
     icon: help-circle

--- a/src/_layouts/help.erb
+++ b/src/_layouts/help.erb
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<%= render Help::Sidebar.new(metadata: site.metadata, resource: resource, page_list: collections.help.resources) %>
+<%= render Help::Sidebar.new(metadata: site.metadata, current: resource) %>
 <main>
   <div class="main-content">
     <button data-button-style="secondary" data-button-size="small" data-toggle-target="button" data-action="toggle#click">


### PR DESCRIPTION
Building the sidebar object in a builder so it gets executed only once. Thanks to this, we go from a 24s building time to 4s.

Also I removed the field `type` in `sidebar.yml`, we will rely on the presence of items to determine if they're a sub menu.

It seems it doesn't change the small lag when visiting the docs for the first time but it will be more comfortable when editing files.