### PR TITLE
docs: make categories collapsible

### DIFF
--- a/frontend/javascript/controllers/sidebar_controller.js
+++ b/frontend/javascript/controllers/sidebar_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class Sidebar extends Controller {
+  static targets = ["expandable"]
+
+  connect() {
+    this.expandableTargets.forEach(target => {
+      if (!target.querySelector("[data-current-parent]") && !target.querySelector("[aria-current='true']") ) {
+        target.setAttribute("aria-expanded", false);
+      }
+    })
+  }
+
+  toggle(event) {
+    event.preventDefault()
+    const targetId = event.currentTarget.getAttribute("aria-controls")
+    const target = document.getElementById(targetId)
+    target.getAttribute("aria-expanded") === "true" ? target.setAttribute("aria-expanded", false) : target.setAttribute("aria-expanded", true)
+  }
+}

--- a/frontend/styles/atoms/button.css
+++ b/frontend/styles/atoms/button.css
@@ -82,10 +82,19 @@
 :where(.button, button, input[type="submit"], input[type="button"])[data-button-size="small"] {
   gap: var(--spacing-2);
   height: var(--spacing-8);
+
+  svg {
+    height: var(--spacing-3);
+  }
 }
 
-:where(.button, button, input[type="submit"], input[type="button"])[data-button-size="small"] svg {
-  height: var(--spacing-3);
+:where(.button, button, input[type="submit"], input[type="button"])[data-button-size="xsmall"] {
+  gap: var(--spacing-1);
+  height: var(--spacing-5);
+
+  svg {
+    height: var(--spacing-2);
+  }
 }
 
 /* --- button states --- */

--- a/src/_components/help/sidebar.css
+++ b/src/_components/help/sidebar.css
@@ -6,10 +6,10 @@ side-bar {
 
   aside {
     padding: var(--spacing-10) var(--spacing-4);
-  }
-
-  button {
-    display: none;
+  
+    > button {
+      display: none;
+    }
   }
 
   ul {
@@ -28,14 +28,11 @@ side-bar {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-1);
-  
-    > li {
-      padding-inline: var(--spacing-4);
-    }
   }
 
   .sidebar-sublist {
     border-left: var(--border-default);
+    display: none;
     list-style-type: none;
     margin: 0;
     margin-bottom: var(--spacing-2);
@@ -47,14 +44,9 @@ side-bar {
 
     .item {
       border-left: 2px solid transparent;
-      border-radius: 0;
+      border-radius: 0 var(--border-radius-medium) var(--border-radius-medium) 0;
       margin-left: -1px;
       padding-left: var(--spacing-5);
-
-      &[aria-current="true"] {
-        background: none;
-        border-color: var(--base-color);
-      }
     }
   }
 

--- a/src/_components/help/sidebar.erb
+++ b/src/_components/help/sidebar.erb
@@ -4,9 +4,11 @@
       <svg width="11" height="12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m10 6 .543.517a.75.75 0 0 0 0-1.034L10 6ZM0 6.75h10v-1.5H0v1.5Zm10.543-1.267-4.762-5-1.086 1.034 4.762 5 1.086-1.034Zm-1.086 0-4.762 5 1.086 1.034 4.762-5-1.086-1.034Z" fill="#025FD7"/></svg>
       Hide menu
     </button>
-    <ul class="sidebar-list">
+    <ul class="sidebar-list" data-controller="sidebar">
       <% @site.data.help_sidebar.each do |page| %>
-        <%= render Help::Sidebar::Item.new(page: page, current: @current) %>
+        <li>
+          <%= render Help::Sidebar::Item.new(page: page, current: @current) %>
+        </li>
       <% end %>
     </ul>
   </aside>

--- a/src/_components/help/sidebar/item.css
+++ b/src/_components/help/sidebar/item.css
@@ -1,16 +1,17 @@
 side-item {
-  .item,
-  .item:where(:focus, :visited) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2) var(--gap-small);
+
+  .item {
     align-items: center;
     border-radius: var(--border-radius-medium);
-    color: var(--text-color);
-    display: flex;
+    display: inline-flex;
     gap: var(--gap-small);
     padding: var(--spacing-1) var(--spacing-3);
-    text-decoration: none;
 
-    &:is(a):hover {
-      color: var(--base-color);
+    &[data-current-parent="true"] {
+      color: var(--link-color);
     }
 
     &[aria-current="true"] {
@@ -18,8 +19,47 @@ side-item {
       color: var(--link-color);
     }
 
-    svg {
+    > :where(a, a:focus, a:visited, div) {
+      color: currentColor;
+      flex-grow: 1;
+      text-decoration: none;
+    }
+
+    .link:hover {
+      color: var(--base-color);
+    }
+
+    > svg {
       width: 1em;
     }
+  
+    li {
+      display: inline-flex;
+    }
+  }
+
+  button {
+    font-size: .75rem;
+    height: var(--spacing-6);
+    padding: 0 var(--spacing-1);
+    width: fit-content;
+
+    svg {
+      height: 0.5em;
+    }
+  }
+
+  &[aria-expanded="true"] {
+    > .item > button svg {
+      rotate: 90deg;
+    }
+
+    > .sidebar-sublist {
+      display: block
+    }
+  }
+
+  .sidebar-sublist [data-current-parent="true"] {
+    background-color: revert;
   }
 }

--- a/src/_components/help/sidebar/item.erb
+++ b/src/_components/help/sidebar/item.erb
@@ -1,22 +1,28 @@
-<side-item>
-  <li>
+<side-item id="<%= category_id %>"<% if @items.present? %> aria-expanded="true" data-sidebar-target="expandable"<% end %>>
+  <div class="item"<% if @is_current %> aria-current="true"<% elsif @is_parent %>data-current-parent="true"<% end %>>
+    <%= svg "images/icons/#{@icon}.svg" if @icon.present? %>
     <% if @resource.present? %>
-      <a class="item" href="<%= @resource.relative_url %>"<% if @is_current %> aria-current="true"<% end %>>
-        <%= svg "images/icons/#{@icon}.svg" if @icon.present? %>
+      <a class="link" href="<%= @resource.relative_url %>">
         <%= @label %>
       </a>
     <% else %>
-      <div class="item"<% if @is_current %> aria-current="true"<% end %>>
-        <%= svg "images/icons/#{@icon}.svg" if @icon.present? %>
+      <a href="" aria-controls="<%= category_id %>" data-action="click->sidebar#toggle">
         <%= @label %>
-      </div>
+      </a>
     <% end %>
     <% if @items.present? %>
-      <ul class="sidebar-sublist">
-        <% @items.each do |item| %>
-          <%= render Help::Sidebar::Item.new(page: item, current: @current) %>
-        <% end %>
-      </ul>
+      <button data-button-style="secondary" data-button-size="xsmall" aria-controls="<%= category_id %>" data-action="sidebar#toggle">
+        <%= svg "images/icons/caret-right.svg" %>
+      </button>
     <% end %>
-  </li>
+  </div>
+  <% if @items.present? %>
+    <ul class="sidebar-sublist">
+      <% @items.each do |item| %>
+        <li>
+          <%= render Help::Sidebar::Item.new(page: item, current: @current) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
 </side-item>

--- a/src/_components/help/sidebar/item.rb
+++ b/src/_components/help/sidebar/item.rb
@@ -3,9 +3,23 @@ class Help::Sidebar::Item < Bridgetown::Component
     @page = page
     @current = current
     @resource = @page[:resource]
-    @is_current = @resource.present? && @resource.path == @current.path
     @icon = @page[:icon]
     @label = @page[:label]
     @items = @page[:items]
+    @is_current = @resource&.path == @current.path
+    @is_parent = is_parent
+  end
+
+  def category_id
+    @label.parameterize
+  end
+
+  def is_parent
+    if @items.present?
+      current_child = @items&.find do |item|
+        item[:resource].path == @current.path
+      end
+      return !!current_child
+    end
   end
 end

--- a/src/images/icons/caret-right.svg
+++ b/src/images/icons/caret-right.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="10" viewBox="0 0 6 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 9L5 5L1 0.999999" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Adds a button on the side of parent items.
Items are collapsed by default unless they're the current page or parent to the current page.

If parent is not an actual page but just a category (cf _Documentation customization_ or _Account_), clicking it will expand the item list as well. However, they will not turn blue on hover.

Tell me what you think about it!