### PR TITLE
Use Netlify _redirects file instead of the main config file

### DIFF
--- a/bridgetown.config.yml
+++ b/bridgetown.config.yml
@@ -22,6 +22,8 @@ url: "https://docs.bump.sh" # the base hostname & protocol for your site, e.g. h
 permalink: simple
 template_engine: erb
 
+include: ["_redirects"]
+
 # Other options you might want to investigate:
 #
 # base_path: "/" # the subpath of your site, e.g. /blog. If you set this option,

--- a/netlify.toml
+++ b/netlify.toml
@@ -42,15 +42,3 @@
   for = "/*.(png|jpg|js|css|svg|woff|ttf|eot|ico|woff2)"
   [headers.values]
     Cache-Control = "private, max-age=0, must-revalidate"
-
-[[redirects]]
-  from = "/"
-  to = "/help"
-
-[[redirects]]
-  from = "/help/getting-started/api-platform/"
-  to = "/guides/bump-sh-tutorials/api-platform/"
-
-[[redirects]]
-  from = "/help/getting-started/fastapi/"
-  to = "/guides/bump-sh-tutorials/fastapi/"

--- a/src/_redirects
+++ b/src/_redirects
@@ -1,0 +1,6 @@
+https://help.bump.sh/markdown-support https://docs.bump.sh/help/specifications-support/markdown-support/
+https://help.bump.sh/references https://docs.bump.sh/help/specifications-support/references/
+https://help.bump.sh/* https://docs.bump.sh/help/:splat/ 301!
+/ /help/ 302
+/help/getting-started/api-platform/ /guides/bump-sh-tutorials/api-platform/
+/help/getting-started/fastapi/ /guides/bump-sh-tutorials/fastapi/


### PR DESCRIPTION
The `_redirects` file is simple to use/maintain than the global config file to handle redirections.
This PR also re-activate the help.bump.sh/* -> docs.bump.sh/* global redirection.