### PR TITLE
Fix help.bump.sh redirects

### DIFF
--- a/src/_redirects
+++ b/src/_redirects
@@ -1,6 +1,6 @@
 https://help.bump.sh/markdown-support https://docs.bump.sh/help/specifications-support/markdown-support/
 https://help.bump.sh/references https://docs.bump.sh/help/specifications-support/references/
-https://help.bump.sh/* https://docs.bump.sh/help/:splat/ 301!
+https://help.bump.sh/* https://docs.bump.sh/:splat 301!
 / /help/ 302
 /help/getting-started/api-platform/ /guides/bump-sh-tutorials/api-platform/
 /help/getting-started/fastapi/ /guides/bump-sh-tutorials/fastapi/


### PR DESCRIPTION
The previous `_redirects` global redirection from help.bump.sh was for SEO and was specific for our Docusaurus migration.
Now, we just want to redirect help.bump.sh/* to docs.bump.sh/*.