### PR TITLE
restore fathom and intercom

### DIFF
--- a/src/_components/shared/third_parties.erb
+++ b/src/_components/shared/third_parties.erb
@@ -1,0 +1,5 @@
+<script src="https://cdn.usefathom.com/script.js" data-site="SBIGOMQN" defer></script>
+<script>
+  window.intercomSettings = { app_id: "hxcxcbgc" };
+  (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/APP_ID';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+</script>

--- a/src/_components/shared/third_parties.rb
+++ b/src/_components/shared/third_parties.rb
@@ -1,0 +1,2 @@
+class Shared::ThirdParties < Bridgetown::Component
+end

--- a/src/_layouts/default.erb
+++ b/src/_layouts/default.erb
@@ -10,5 +10,6 @@
     <%= yield %>
 
     <%= render Shared::Footer.new(hide: data.hide_footer) %>
+    <%= render Shared::ThirdParties.new %>
   </body>
 </html>


### PR DESCRIPTION
Forgot to restore third party apps when switching to the new content hub, oops!