### PR TITLE
make h3 smaller for better differentiation with h2

### DIFF
--- a/frontend/styles/pages/help.css
+++ b/frontend/styles/pages/help.css
@@ -42,8 +42,13 @@
       font-size: 1.5rem;
     }
   
+    h3 {
+      font-size: 1.25rem;
+    }
+
     h1, h2, h3, h4 {
       font-weight: var(--font-weight-normal);
+      margin-block-end: 0;
       scroll-margin-top: var(--spacing-8);
     }
 


### PR DESCRIPTION
Changed the size of the `h3` element that was too close from `h2`, though the difference now is still light, maybe we should make headings more differents?