### PR TITLE
guides: reduce guide number and change link to categories style

### DIFF
--- a/frontend/styles/pages/category.css
+++ b/frontend/styles/pages/category.css
@@ -28,7 +28,6 @@
   }
 
   guide-list .list-container {
-    grid-template-columns: repeat(2, 1fr);
     padding-block: var(--spacing-20);
   }
 

--- a/frontend/styles/pages/guides.css
+++ b/frontend/styles/pages/guides.css
@@ -6,6 +6,36 @@
     gap: var(--gap-xlarge);
     margin-block: var(--spacing-16);
   }
+
+  guide-list .list-container {
+    display: flex;
+
+    .card:not(.browse-all) {
+      width: 28%;
+    }
+
+    .browse-all {
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      width: 10%;
+
+      em {
+        color: var(--base-color);
+        font-style: normal;
+      }
+    }
+
+    @container guides (width < 800px) {
+      flex-direction: column;
+
+      .card:not(.browse-all),
+      .browse-all {
+        min-height: 100px;
+        width: 100%;
+      }
+    }
+  }
 }
 
 .guide {

--- a/src/_components/guides/category/section.erb
+++ b/src/_components/guides/category/section.erb
@@ -6,5 +6,5 @@
     <% end %>
   </div>
 
-  <%= render Guides::List.new(resources: @resources, category_name: @category_name, show_browse_button: true) %>
+  <%= render Guides::List.new(resources: @resources.first(3), category_name: @category_name, remaining_count: @remaining_count) %>
 </guide-category>

--- a/src/_components/guides/category/section.erb
+++ b/src/_components/guides/category/section.erb
@@ -4,13 +4,7 @@
     <% if @description.present? %>
       <p><%= @description %></p>
     <% end %>
-    <% if @category_name != "All" %>
-      <a href="<%= relative_url "/guides/#{Bridgetown::Utils.slugify(@category_name)}" %>">
-        Browse all <%= @category_name %> Guides
-        <%= svg "images/icons/arrow-right.svg" %>
-      </a>
-    <% end %>
   </div>
 
-  <%= render Guides::List.new(resources: @resources) %>
+  <%= render Guides::List.new(resources: @resources, category_name: @category_name, show_browse_button: true) %>
 </guide-category>

--- a/src/_components/guides/category/section.rb
+++ b/src/_components/guides/category/section.rb
@@ -6,10 +6,11 @@ class Guides::Category::Section < Bridgetown::Component
     @site = Bridgetown::Current.site
     @category_name = category.name
     @description = category.description
-    @resources = if @category_name == "Latest"
-      @site.collections.guides.resources.first(4)
-    else
-      @site.collections.guides.resources.select { |guide| guide.data.categories.find { |category| Bridgetown::Utils.slugify(category) == Bridgetown::Utils.slugify(@category_name)} }.first(3)
+    @resources = @site.collections.guides.resources.select do |guide|
+      guide.data.categories.find do |category|
+        Bridgetown::Utils.slugify(category) == Bridgetown::Utils.slugify(@category_name)
+      end
     end
+    @remaining_count = @resources.count - 3
   end
 end

--- a/src/_components/guides/category/section.rb
+++ b/src/_components/guides/category/section.rb
@@ -9,7 +9,7 @@ class Guides::Category::Section < Bridgetown::Component
     @resources = if @category_name == "Latest"
       @site.collections.guides.resources.first(4)
     else
-      @site.collections.guides.resources.select { |guide| guide.data.categories.find { |category| Bridgetown::Utils.slugify(category) == Bridgetown::Utils.slugify(@category_name)} }.first(4)
+      @site.collections.guides.resources.select { |guide| guide.data.categories.find { |category| Bridgetown::Utils.slugify(category) == Bridgetown::Utils.slugify(@category_name)} }.first(3)
     end
   end
 end

--- a/src/_components/guides/list.css
+++ b/src/_components/guides/list.css
@@ -4,7 +4,7 @@ guide-list {
 
   .list-container {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
     gap: var(--gap-medium);
     list-style-type: none;
     padding: 0;
@@ -14,16 +14,7 @@ guide-list {
     .card {
       background-color: var(--bg-color);
       box-sizing: border-box;
-      min-height: 290px;
-    }
-
-    @container guide-category (width < 800px) {
-      flex-direction: column;
-
-      .card {
-        min-height: 100px;
-        width: 100%;
-      }
+      min-height: 270px;
     }
   }
 

--- a/src/_components/guides/list.erb
+++ b/src/_components/guides/list.erb
@@ -7,9 +7,9 @@
         <%= render Shared::Taglist.new(tags: resource.data.tags) %>
       </a>
     <% end %>
-    <% if @show_browse_button %>
+    <% if @remaining_count > 0 %>
       <a href="<%= relative_url "/guides/#{Bridgetown::Utils.slugify(@category_name)}" %>" class="card browse-all">
-        <span>Browse more <strong><%= @category_name %></strong> guides</span>
+        <span>Browse <strong><%= @remaining_count %> more </strong> guides</span>
         <%= svg "images/icons/arrow-right-circle.svg" %>
       </a>
     <% end %>

--- a/src/_components/guides/list.erb
+++ b/src/_components/guides/list.erb
@@ -7,5 +7,11 @@
         <%= render Shared::Taglist.new(tags: resource.data.tags) %>
       </a>
     <% end %>
+    <% if @show_browse_button %>
+      <a href="<%= relative_url "/guides/#{Bridgetown::Utils.slugify(@category_name)}" %>" class="card browse-all">
+        <span>Browse more <strong><%= @category_name %></strong> guides</span>
+        <%= svg "images/icons/arrow-right-circle.svg" %>
+      </a>
+    <% end %>
   </div>
 </guide-list>

--- a/src/_components/guides/list.rb
+++ b/src/_components/guides/list.rb
@@ -1,8 +1,8 @@
 class Guides::List < Bridgetown::Component
-  def initialize(resources:, category_name:, css_classes: "", show_browse_button: false)
+  def initialize(resources:, category_name:, css_classes: "", remaining_count: 0)
     @resources = resources
     @category_name = category_name
     @css_classes = css_classes
-    @show_browse_button = show_browse_button
+    @remaining_count = remaining_count
   end
 end

--- a/src/_components/guides/list.rb
+++ b/src/_components/guides/list.rb
@@ -1,6 +1,8 @@
 class Guides::List < Bridgetown::Component
-  def initialize(resources:, css_classes: "")
+  def initialize(resources:, category_name:, css_classes: "", show_browse_button: false)
     @resources = resources
+    @category_name = category_name
     @css_classes = css_classes
+    @show_browse_button = show_browse_button
   end
 end

--- a/src/_pages/guides/category.erb
+++ b/src/_pages/guides/category.erb
@@ -25,6 +25,6 @@ prototype:
       <% end %>
     </ul>
   </aside>
-  <%= render Guides::List.new(resources: paginator.resources) %>
+  <%= render Guides::List.new(resources: paginator.resources, category_name: @category.name) %>
 </div>
 <%= render Shared::Pagination.new(paginator: paginator) %>

--- a/src/images/icons/arrow-right-circle.svg
+++ b/src/images/icons/arrow-right-circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right-circle"><circle cx="12" cy="12" r="10"/><path d="M8 12h8"/><path d="m12 16 4-4-4-4"/></svg>


### PR DESCRIPTION
* sets the number of displayed guides by category to 3
* moves links to categories from header to card list 

![image](https://github.com/bump-sh/docs/assets/1301085/1985a581-c595-450e-8b27-1b0a5077552f)
