### PR TITLE
guides: show category list

### DIFF
--- a/frontend/styles/pages/category.css
+++ b/frontend/styles/pages/category.css
@@ -1,32 +1,4 @@
 .category {
-  aside {
-    h2 {
-      font-size: 1.23rem;
-    }
-    ul {
-      display: flex;
-      flex-direction: column;
-      flex-wrap: wrap;
-      gap: var(--gap-xsmall);
-      list-style-type: none;
-      padding: 0;
-    }
-
-    a {
-      border-radius: var(--border-radius-medium);
-      color: var(--text-color);
-      display: flex;
-      padding: var(--spacing-1) var(--spacing-3);
-      text-decoration: none;
-  
-      &:hover,
-      &[aria-current="true"] {
-        background-color: var(--bg-color-selected);
-        color: var(--link-color);
-      }
-    }
-  }
-
   guide-list .list-container {
     padding-block: var(--spacing-20);
   }

--- a/frontend/styles/pages/guides.css
+++ b/frontend/styles/pages/guides.css
@@ -7,33 +7,20 @@
     margin-block: var(--spacing-16);
   }
 
-  guide-list .list-container {
-    display: flex;
+  guide-list {
+    .list-container {
+      grid-template-columns: repeat(3, 1fr);
 
-    .card:not(.browse-all) {
-      width: 28%;
+      @container guides (width < 800px) {
+        grid-template-columns: 1fr;
+      }
     }
 
     .browse-all {
-      align-items: center;
+      flex-direction: row;
+      gap: var(--gap-small);
       justify-content: center;
-      text-align: center;
-      width: 10%;
-
-      em {
-        color: var(--base-color);
-        font-style: normal;
-      }
-    }
-
-    @container guides (width < 800px) {
-      flex-direction: column;
-
-      .card:not(.browse-all),
-      .browse-all {
-        min-height: 100px;
-        width: 100%;
-      }
+      padding-block: var(--spacing-4);
     }
   }
 }

--- a/plugins/builders/helpers.rb
+++ b/plugins/builders/helpers.rb
@@ -2,6 +2,10 @@ class Builders::Helpers < SiteBuilder
   def build
     liquid_tag "toc", :toc_template
     helper "toc", :toc_template
+
+    helper :guide_category_url do |category|
+      "/guides/#{category.downcase.split(" ").join("-")}"
+    end
   end
 
   def toc_template(*)

--- a/plugins/builders/helpers.rb
+++ b/plugins/builders/helpers.rb
@@ -4,7 +4,7 @@ class Builders::Helpers < SiteBuilder
     helper "toc", :toc_template
 
     helper :guide_category_url do |category|
-      "/guides/#{category.downcase.split(" ").join("-")}"
+      "/guides/#{Bridgetown::Utils.slugify(category)}"
     end
   end
 

--- a/src/_components/categories/sidebar.css
+++ b/src/_components/categories/sidebar.css
@@ -1,0 +1,20 @@
+.category-sidebar {
+  h2 {
+    font-size: 1.25rem;
+  }
+
+  ul {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    gap: var(--gap-small);
+    list-style-type: none;
+    padding: 0;
+  }
+
+  a:hover,
+  a[aria-current="true"] {
+    background-color: var(--bg-color-selected);
+    color: var(--link-color);
+  }
+}

--- a/src/_components/categories/sidebar.erb
+++ b/src/_components/categories/sidebar.erb
@@ -1,0 +1,8 @@
+<aside class="category-sidebar">
+  <h2>All categories</h2>
+  <ul>
+    <% @categories.each do |category| %>
+      <%= render Categories::Sidebar::Item.new(category: category, current: @current) %>
+    <% end %>
+  </ul>
+</aside>

--- a/src/_components/categories/sidebar.rb
+++ b/src/_components/categories/sidebar.rb
@@ -1,0 +1,6 @@
+class Categories::Sidebar < Bridgetown::Component
+  def initialize(categories:, current: nil)
+    @categories = categories
+    @current = current
+  end
+end

--- a/src/_components/categories/sidebar/item.erb
+++ b/src/_components/categories/sidebar/item.erb
@@ -1,5 +1,5 @@
 <li>
-  <a href="<%= relative_url "/guides/#{slugified_name}" %>" <% if is_current? %>aria-current="true"<% end %>>
+  <a href="<%= relative_url guide_category_url(@category.name) %>" <% if is_current? %>aria-current="true"<% end %>>
     <%= @category.name %>
   </a>
 </li>

--- a/src/_components/categories/sidebar/item.erb
+++ b/src/_components/categories/sidebar/item.erb
@@ -1,5 +1,5 @@
 <li>
-  <a href="<%= relative_url guide_category_url(@category.name) %>" <% if is_current? %>aria-current="true"<% end %>>
+  <a class="label" href="<%= relative_url guide_category_url(@category.name) %>" <% if is_current? %>aria-current="true"<% end %>>
     <%= @category.name %>
   </a>
 </li>

--- a/src/_components/categories/sidebar/item.rb
+++ b/src/_components/categories/sidebar/item.rb
@@ -1,5 +1,5 @@
 class Categories::Sidebar::Item < Bridgetown::Component
-  def initialize(category:, current:)
+  def initialize(category:, current: false)
     @category = category
     @current = current
   end

--- a/src/_components/guides/list.css
+++ b/src/_components/guides/list.css
@@ -1,5 +1,8 @@
 guide-list {
   container: guide-list / inline-size;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-medium);
   width: 100%;
 
   .list-container {

--- a/src/_components/guides/list.erb
+++ b/src/_components/guides/list.erb
@@ -7,11 +7,11 @@
         <%= render Shared::Taglist.new(tags: resource.data.tags) %>
       </a>
     <% end %>
-    <% if @remaining_count > 0 %>
-      <a href="<%= relative_url "/guides/#{Bridgetown::Utils.slugify(@category_name)}" %>" class="card browse-all">
-        <span>Browse <strong><%= @remaining_count %> more </strong> guides</span>
-        <%= svg "images/icons/arrow-right-circle.svg" %>
-      </a>
-    <% end %>
   </div>
+  <% if @remaining_count > 0 %>
+    <a href="<%= relative_url "/guides/#{Bridgetown::Utils.slugify(@category_name)}" %>" class="card browse-all">
+      <span>Browse <strong><%= @remaining_count %> more </strong> guides</span>
+      <%= svg "images/icons/arrow-right-circle.svg" %>
+    </a>
+  <% end %>
 </guide-list>

--- a/src/_components/guides/sidebar.erb
+++ b/src/_components/guides/sidebar.erb
@@ -7,7 +7,7 @@
       <dd><a class="label" href="<%= relative_url guide_category_url(@category) %>"><%= @category %></a></dd>
       <% if @tags.present? %>
         <dt>Tags</dt>
-        <dd><%= render Shared::Taglist.new(tags: @tags) %></dd>
+        <dd><%= render Guides::Taglist.new(tags: @tags) %></dd>
       <% end %>
       <dt>Last update</dt>
       <dd><%= @update %></dd>

--- a/src/_components/guides/sidebar.erb
+++ b/src/_components/guides/sidebar.erb
@@ -4,7 +4,7 @@
     <hr>
     <dl>
       <dt>Posted in</dt>
-      <dd><a class="label" href="<%= relative_url "/guides/#{@category.downcase.split(" ").join("-")}" %>"><%= @category %></a></dd>
+      <dd><a class="label" href="<%= relative_url guide_category_url(@category) %>"><%= @category %></a></dd>
       <% if @tags.present? %>
         <dt>Tags</dt>
         <dd><%= render Shared::Taglist.new(tags: @tags) %></dd>

--- a/src/_components/guides/taglist.erb
+++ b/src/_components/guides/taglist.erb
@@ -1,0 +1,5 @@
+<tag-list>
+  <% @tags.each do |tag| %>
+    <a href="<%= guide_category_url(tag) %>" class="label" data-label-status="info"><%= tag %></a>
+  <% end %>
+</tag-list>

--- a/src/_components/guides/taglist.rb
+++ b/src/_components/guides/taglist.rb
@@ -1,0 +1,2 @@
+class Guides::Taglist < Shared::TagList
+end

--- a/src/_components/shared/hero.css
+++ b/src/_components/shared/hero.css
@@ -14,4 +14,8 @@ page-hero {
   p {
     font-size: 1.25rem;
   }
+
+  tag-list {
+    margin-top: var(--gap-small);
+  }
 }

--- a/src/_components/shared/hero.erb
+++ b/src/_components/shared/hero.erb
@@ -3,5 +3,6 @@
   <% if @description.present? %>
     <p><%= @description %></p>
   <% end %>
+  <%= content %>
   <%= render Shared::Taglist.new(tags: @tags) %>
 </page-hero>

--- a/src/_layouts/guides.erb
+++ b/src/_layouts/guides.erb
@@ -2,10 +2,20 @@
 layout: default
 ---
 
+<% @categories = @site.data.guides.categories %>
 <main class="wrapper">
-  <%= render Shared::Hero.new(title: data.title, description: "Learn about APIs at large, and how to use Bump.sh in your API ecosystem.") %>
+  <%= render Shared::Hero.new(title: data.title,
+                              description: "Learn about APIs at large, and how to use Bump.sh in your API ecosystem.") do %>
+    <% if @categories.present? %>
+      <tag-list>
+        <% @categories.each do |category| %>
+          <a class="label" href="<%= relative_url guide_category_url(category.name) %>"><%= category.name %></a>
+        <% end %>
+      </tag-list>
+    <% end %>
+  <% end %>
   <div class="section-container">
-    <% @site.data.guides.categories.each do |category| %>
+    <% @categories.each do |category| %>
       <%= render Guides::Category::Section.new(category: category) %>
     <% end %>
   </div>

--- a/src/_layouts/guides.erb
+++ b/src/_layouts/guides.erb
@@ -5,19 +5,14 @@ layout: default
 <% @categories = @site.data.guides.categories %>
 <main class="wrapper">
   <%= render Shared::Hero.new(title: data.title,
-                              description: "Learn about APIs at large, and how to use Bump.sh in your API ecosystem.") do %>
-    <% if @categories.present? %>
-      <tag-list>
-        <% @categories.each do |category| %>
-          <a class="label" href="<%= relative_url guide_category_url(category.name) %>"><%= category.name %></a>
-        <% end %>
-      </tag-list>
-    <% end %>
-  <% end %>
-  <div class="section-container">
-    <% @categories.each do |category| %>
-      <%= render Guides::Category::Section.new(category: category) %>
-    <% end %>
+                              description: "Learn about APIs at large, and how to use Bump.sh in your API ecosystem.") %>
+  <div class="double-pane">
+    <%= render Categories::Sidebar.new(categories: @categories) %>
+    <guide-list class="section-container">
+      <% @categories.each do |category| %>
+        <%= render Guides::Category::Section.new(category: category) %>
+      <% end %>
+    </guide-list>
+    <%= yield %>
   </div>
-  <%= yield %>
 </main>

--- a/src/_pages/guides/category.erb
+++ b/src/_pages/guides/category.erb
@@ -17,14 +17,7 @@ prototype:
   <%= render Shared::Hero.new(title: data.category.titleize) %>
 <% end %>
 <div class="double-pane">
-  <aside>
-    <h2>All categories</h2>
-    <ul>
-      <% site.data.guides.categories.each do |category| %>
-        <%= render Categories::Sidebar::Item.new(category: category, current: data.category) %>
-      <% end %>
-    </ul>
-  </aside>
+  <%= render Categories::Sidebar.new(categories: site.data.guides.categories, current: data.category) %>
   <%= render Guides::List.new(resources: paginator.resources, category_name: @category.name) %>
 </div>
 <%= render Shared::Pagination.new(paginator: paginator) %>


### PR DESCRIPTION
This PR adds a list of tags under the Guides page header so users can navigate easily through categories.