### PR TITLE
guide: add 'paths:' keyword in the YAML example

### DIFF
--- a/src/_guides/openapi/advanced-ref-usage.md
+++ b/src/_guides/openapi/advanced-ref-usage.md
@@ -17,6 +17,7 @@ The [OpenAPI Documentation](https://learn.openapis.org/) includes a brilliant ex
 This has several parts that are used several times, so instead of copy-pasting everything they've defined reusable `components` for both `schemas` and `parameters`. 
 
 ```yaml
+paths:
   # Whole board operations
   /board:
     get:


### PR DESCRIPTION
For clarity, let's put back the `paths:` keyword on top of the YAML
example.

Follow-up to #136