### PR TITLE
section(ci): move some bits and add a dedicated “CI” page

### DIFF
--- a/src/_data/sidebar.yml
+++ b/src/_data/sidebar.yml
@@ -19,6 +19,8 @@ help:
     items:
       - label: Github Action
         link: /continuous-integration/github-actions/
+      - label: CI
+        link: /continuous-integration/ci/
       - label: CLI
         link: /continuous-integration/cli/
       - label: API (advanced)

--- a/src/_help/continuous-integration/ci.md
+++ b/src/_help/continuous-integration/ci.md
@@ -1,0 +1,34 @@
+---
+title: Continuous Integration (CI)
+---
+
+- TOC
+{:toc}
+
+All our generic build processes are stored in a dedicated [public repository called `bump-ci-example`](https://github.com/bump-sh/bump-ci-example/blob/master/.travis.yml). Those processes are defined thanks to dedicated configuration files and scripts which uses the [Bump.sh CLI](/help/continuous-integration/cli/) under the hood.
+
+If you encounter an issue or have suggestions on those examples, please do [file a ticket on the dedicated repo](https://github.com/bump-sh/bump-ci-example/issues) we would love to hear your feedback.
+
+## Gitlab CI
+
+The provided example has is a two stage delivery process:
+- The `test` stage will run an API definition **diff** on all your branches except the `main` one, to compare the changed document file with your Bump.sh documentation. It will also comment with the diff content on the related Merge Request on Gitlab if it exists.
+- The `deploy` stage will run only on your `main` branch, once your API definition was merged to your `main` branch it will automatically be **deployed** to your Bump.sh documentation.
+
+Copy-paste the following files in your own project to see start your first Bump related pipeline:
+- the [`.gitlab-ci.yml` pipeline file](https://github.com/bump-sh/bump-ci-example/blob/master/.gitlab-ci.yml)
+- the whole [`.gitlab/` directory](https://github.com/bump-sh/bump-ci-example/tree/master/.gitlab).
+
+## CircleCI
+
+The CircleCI example we provide helps to **validate** your definition file on pull requests, and then **deploy** a definition file change merged in your `main` branch.
+
+Copy-paste the following directory in your own project to see the builds running:
+- [`.circleci/` directory](https://github.com/bump-sh/bump-ci-example/blob/master/.circleci/config.yml)
+
+## Travis CI
+
+Similarly to the CircleCI configuration, this Travis CI example will help to **validate** your definition file on pull requests, and then **deploy** a definition file change merged in your `main` branch.
+
+Copy-paste the following file in your own project to see the builds running on Travis:
+- [`.travis.yml` file example](https://github.com/bump-sh/bump-ci-example/blob/master/.travis.yml)

--- a/src/_help/continuous-integration/index.md
+++ b/src/_help/continuous-integration/index.md
@@ -12,14 +12,15 @@ How to integrate your documentation deployment to your Continuous Integration (C
 There are multiple ways to integrate with Bump.sh:
 
 - Using the [Github Action](/help/continuous-integration/github-actions)
-- Using the [CLI](/help/continuous-integration/cli)
+- Using other [CI examples](/help/continuous-integration/ci)
+- Manually using the [CLI](/help/continuous-integration/cli)
 - More advanced usage can be done with the [API](/help/continuous-integration/api)
 
 ## Steps to integrate in your CI
 
-Here, we are presenting the process recommended to our users, but feel free to adapt it to your own workflow/requirements.
+We are presenting the process recommended to our users, but feel free to adapt it to your own workflow/requirements.
 
-We recommend two steps in your automation flow:
+We advise to setup two steps in your automation flow:
 - a [**validation** and **diff** step](#api-diff--validation-of-the-documentation-file) during development
 - followed by a [**deployment** step](#deploy-your-api-document) on production merges.
 
@@ -45,6 +46,14 @@ The GitHub action example uses a dedicated action we crafted especially for you.
 - [API diff & validation step](/help/continuous-integration/github-actions/#diff-on-pull-requests-only)
 - [Deploy to your documentation](/help/continuous-integration/github-actions/#deploy-documentation-only)
 
+### Other Continuous Integration tools (CI)
+
+The CI examples are here to help you build a similar process described with our GitHub action. We try to keep some specially crafted scripts for you to build the same experience for your own tools:
+
+- Example [Gitlab CI pipelines](/help/continuous-integration/ci/#gitlab-ci).
+- Example [delivery process with a CircleCI](/help/continuous-integration/ci/#circleci) config file.
+- Example [Travis CI Build Configuration](/help/continuous-integration/ci/#travis-ci)
+
 ### CLI
 
 The CLI can be used in your custom CI scripts with the two available recommendeded steps:
@@ -52,11 +61,6 @@ The CLI can be used in your custom CI scripts with the two available recommended
 - [`bump diff`](/help/continuous-integration/cli/#api-diff-of-your-changes) to check the changes & validate the API document
 - [`bump deploy`](/help/continuous-integration/cli/#deploy-a-file) to publish to your Bump.sh documentation
 
-Here are examples for integrating Bump.sh CLI with other commonly used CI products:
-
-- CircleCI : [https://github.com/bump-sh/bump-ci-example/blob/master/.circleci/config.yml](https://github.com/bump-sh/bump-ci-example/blob/master/.circleci/config.yml)
-- Gitlab CI: [https://github.com/bump-sh/bump-ci-example/blob/master/.gitlab-ci.yml ](https://github.com/bump-sh/bump-ci-example/blob/master/.gitlab-ci.yml )
-- Travis CI: [ https://github.com/bump-sh/bump-ci-example/blob/master/.travis.yml]( https://github.com/bump-sh/bump-ci-example/blob/master/.travis.yml)
 
 ## Recommendation
 

--- a/src/_help/getting-started/concepts.md
+++ b/src/_help/getting-started/concepts.md
@@ -1,5 +1,5 @@
 ---
-title: %Important concepts
+title: Important concepts
 ---
 
 - TOC


### PR DESCRIPTION
As discussed with Seb, it feels better to have a dedicated page for
“All other CI tools” where we can detail the usage of our suggested
configuration files for CI systems that are different than GitHub
Action.

We could improve this new page, but this is my early contribution to
this new re-arragement of the docs.