### PR TITLE
fix list numbers when adding block in between

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,7 @@ The excerpt is a small description of the guide content that will show on the gu
 
 Images go under [`src/images`](https://github.com/bump-sh/docs/tree/main/src/images) and can be called with `![](/images/guides/<your_image_name>)`.
 
+##### Gotchas
+* Ordered lists: if you need to any kind of blocks in your ordered list item, make sure it immediately follows the numbered paragraph line (no empty line in between). You might also want to [indent your block to line up with the first non-space character after the list item marker](https://stackoverflow.com/questions/34987908/embed-a-code-block-in-a-list-item-with-proper-indentation-in-kramdown). Just do both for safety!
+
 Then you can let your ~~pen~~ keyboard handle the content!

--- a/src/_guides/bump-sh-tutorials/api-platform.md
+++ b/src/_guides/bump-sh-tutorials/api-platform.md
@@ -13,19 +13,17 @@ The following assumes your local machine is configured with PHP and API Platform
 1. [Create and name](https://bump.sh/docs/new?utm_source=bump&utm_medium=content_hub&utm_campaign=getting_started) your first API documentation. Then, retrieve the name and token of this documentation from the _CI deployment_ settings page.
 
 2. Install the Bump.sh CLI with [npm](https://docs.npmjs.com/cli/v9/configuring-npm/install?v=true) as below, or use [alternative options](/help/continuous-integration/cli), with
-
-```bash
-npm install -g bump-cli
-```
+  ```bash
+  npm install -g bump-cli
+  ```
 
 3. Launch your local server with [Docker](https://api-platform.com/docs/distribution/#using-the-api-platform-distribution-recommended) or [Symfony](https://api-platform.com/docs/distribution/#using-symfony-cli)
 
 4. Deploy your doc to Bump.sh with
-
-```bash
-bump deploy https://localhost/docs.json \
-  --doc my-documentation-name \
-  --token my-documentation-token
-```
+  ```bash
+  bump deploy https://localhost/docs.json \
+    --doc my-documentation-name \
+    --token my-documentation-token
+  ```
 
 That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/help/getting-started/quick-start#customization-options).

--- a/src/_guides/bump-sh-tutorials/fastapi.md
+++ b/src/_guides/bump-sh-tutorials/fastapi.md
@@ -13,25 +13,21 @@ The following assumes your local machine is configured with Python and FastAPI, 
 1. [Create and name](https://bump.sh/docs/new?utm_source=bump&utm_medium=content_hub&utm_campaign=getting_started) your first API documentation. Then, retrieve the name and token of this documentation from the _CI deployment_ settings page.
 
 2. Install the Bump.sh CLI with [npm](https://docs.npmjs.com/cli/v9/configuring-npm/install?v=true) as below, or use [alternative options](/help/continuous-integration/cli), with
-
-```bash
-npm install -g bump-cli
-```
+  ```bash
+  npm install -g bump-cli
+  ```
 
 3. Launch your local server with
-
-```bash
-uvicorn main:app --reload
-```
-
-**Note:** You might need, depending on how you usually run your Python commands, to prepend them with `python3 -m`.
+  ```bash
+  uvicorn main:app --reload
+  ```
+  **Note:** You might need, depending on how you usually run your Python commands, to prepend them with `python3 -m`.
 
 4. Deploy your doc to Bump.sh with
-
-```bash
-bump deploy http://127.0.0.1:8000/openapi.json \
-  --doc my-documentation-name \
-  --token my-documentation-token
-```
+  ```bash
+  bump deploy http://127.0.0.1:8000/openapi.json \
+    --doc my-documentation-name \
+    --token my-documentation-token
+  ```
 
 That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/help/getting-started/quick-start#customization-options).

--- a/src/_guides/bump-sh-tutorials/huma.md
+++ b/src/_guides/bump-sh-tutorials/huma.md
@@ -13,26 +13,22 @@ The following assumes your local machine is configured with Golang and you have 
 1. [Create and name](https://bump.sh/docs/new?utm_source=bump&utm_medium=content_hub&utm_campaign=getting_started) your first API documentation. Then, retrieve the name and token of this documentation from the _CI deployment_ settings page.
 
 2. Install the Bump.sh CLI with [npm](https://docs.npmjs.com/cli/v9/configuring-npm/install?v=true) as below, or use [alternative options](/help/bump-cli), with
-
-```bash
-npm install -g bump-cli
-```
+  ```bash
+  npm install -g bump-cli
+  ```
 
 3. Launch your local server with
-
-```bash
-go run .
-```
-
-This will run not only the application, but it will make API documentation available on <http://127.0.0.1:8000/>.
+  ```bash
+  go run .
+  ```
+  This will run not only the application, but it will make API documentation available on <http://127.0.0.1:8000/>.
 
 4. Deploy your doc to Bump.sh with
-
-```bash
-bump deploy http://127.0.0.1:8888/openapi.yaml \
-  --doc my-documentation-name \
-  --token my-documentation-token
-```
+  ```bash
+  bump deploy http://127.0.0.1:8888/openapi.yaml \
+    --doc my-documentation-name \
+    --token my-documentation-token
+  ```
 
 If for any reason you are unable to download that `openapi.yaml` from a URL despite being able to access it, it's likely some odd network proxy settings on your machine or wifi. Grab it directly with wget or similar.
 


### PR DESCRIPTION
When making ordered lists, numbers will not be contiguous if blocks are added with an empty line after the paragraph so this is more of a copy issue here (or a kramdown issue depending on what you find more convenient).
Guides will be fixed by removing this empty line and setting the right indentation to blocks.

Also added an entry in the contributing guide to help understanding the issue.

Fixes #159 