### PR TITLE
guides: suggestions on a recently merged guide on code-first Rails

### DIFF
--- a/src/_guides/openapi/code-first-rails.md
+++ b/src/_guides/openapi/code-first-rails.md
@@ -133,7 +133,7 @@ Generating Swagger docs ...
 Swagger doc generated at /Users/phil/src/rails-code-first/swagger/v1/swagger.yaml
 ```
 
-**Step 7:** OpenAPI being generated means we can deploy it to Bump.
+**Step 7:** OpenAPI being generated means we can deploy it to Bump.sh.
 
 > Deploying OpenAPI documentation to Bump.sh.
 > - [Create and name](https://bump.sh/docs/new?utm_source=bump&utm_medium=content_hub&utm_campaign=getting_started) your first API documentation.


### PR DESCRIPTION
This commit contains a few suggestions:
- removing white spaces
- Adding a prerequesite sentence to assume the users uses `RSpec`
- Moving the “deploying to bump.sh” laius inside a callout blockquote
- Adding a multiline description for the `Cache-Control` header to
show the power of markdown in the generated docs