### PR TITLE
tweak to formatting for rails guides

### DIFF
--- a/src/_guides/openapi/code-first-rails.md
+++ b/src/_guides/openapi/code-first-rails.md
@@ -165,61 +165,61 @@ It looks like a start, but it's missing a whole lot of the what, and the why, wh
 
 **Step 11:** Going back to `spec/requests/widgets_spec.rb` we leverage the DSL to improve our tests, and improve our OpenAPI. Lets add some headers, a schema to explain how the object is going to look, and a few error responses.
 
-  ```ruby
-    path '/widgets' do
+```ruby
+  path '/widgets' do
 
-    get 'list widgets'  do
-      produces 'application/json'
+  get 'list widgets'  do
+    produces 'application/json'
 
-      response 200, 'successful' do
-        header 'Cache-Control', schema: { type: :string }, description: <<~HEADER
-          This header declares the cacheability of the content so you can skip repeating requests.
+    response 200, 'successful' do
+      header 'Cache-Control', schema: { type: :string }, description: <<~HEADER
+        This header declares the cacheability of the content so you can skip repeating requests.
 
-          Values can be `max-age`, `must-revalidate` and `private`. It can also combine any of those separated by a comma. E.g. `Cache-Control: max-age=604800, must-revalidate`
-        HEADER
+        Values can be `max-age`, `must-revalidate` and `private`. It can also combine any of those separated by a comma. E.g. `Cache-Control: max-age=604800, must-revalidate`
+      HEADER
 
-        schema type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              id: {
-                type: 'string',
-                format: 'uuid',
-                example: '123e4567-e89b-12d3-a456-426614174000',
-              },
-              title: {
-                type: 'string',
-                example: 'Neuralyzer',
-              },
-              created_at: {
-                type: 'string',
-                format: 'date-time',
-              },
-              updated_at: {
-                type: 'string',
-                format: 'date-time',
-              },
-            }
+      schema type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+              format: 'uuid',
+              example: '123e4567-e89b-12d3-a456-426614174000',
+            },
+            title: {
+              type: 'string',
+              example: 'Neuralyzer',
+            },
+            created_at: {
+              type: 'string',
+              format: 'date-time',
+            },
+            updated_at: {
+              type: 'string',
+              format: 'date-time',
+            },
           }
+        }
 
-        example 'application/json', :example_key, [
-          {
-            id: 1,
-            title: 'Neuralyzer',
-          }
-        ]
-        run_test!
-      end
-
-      response 429, 'too many requests' do
-        header 'X-Rate-Limit-Limit', schema: { type: :integer }, description: 'The number of allowed requests in the current period'
-        header 'X-Rate-Limit-Remaining', schema: { type: :integer }, description: 'The number of remaining requests in the current period'
-        header 'X-Rate-Limit-Reset', schema: { type: :integer }, description: 'The number of seconds left in the current period'
-
-        run_test!
-      end
+      example 'application/json', :example_key, [
+        {
+          id: 1,
+          title: 'Neuralyzer',
+        }
+      ]
+      run_test!
     end
-  ```
+
+    response 429, 'too many requests' do
+      header 'X-Rate-Limit-Limit', schema: { type: :integer }, description: 'The number of allowed requests in the current period'
+      header 'X-Rate-Limit-Remaining', schema: { type: :integer }, description: 'The number of remaining requests in the current period'
+      header 'X-Rate-Limit-Reset', schema: { type: :integer }, description: 'The number of seconds left in the current period'
+
+      run_test!
+    end
+  end
+```
 
 This is a lot, but let's walk through some of those changes.
 

--- a/src/_guides/openapi/code-first-rails.md
+++ b/src/_guides/openapi/code-first-rails.md
@@ -15,24 +15,25 @@ _This guide assumes you want to use `RSpec` as your testing framework in your ap
 
 **Step 1:** Add the rswag dependencies to the `Gemfile`.
 
-  ```ruby
-  # Gemfile
-  gem 'rspec-rails'
-  gem 'rswag'
-  ```
+```ruby
+# Gemfile
+gem 'rspec-rails'
+gem 'rswag'
+```
 
 **Step 2:** Install the new dependencies and run the rswag generator.
-  ```bash
-  bundle install
-  ```
-  You'll need to run the [rspec](https://rspec.info/) generator if it's the first time you use rspec.
-  ```
-  rails generate rspec:install
-  ```
-  Then run the rswag generator.
-  ```
-  rails generate rswag:install
-  ```
+
+```bash
+bundle install
+```
+You'll need to run the [rspec](https://rspec.info/) generator if it's the first time you use rspec.
+```
+rails generate rspec:install
+```
+Then run the rswag generator.
+```
+rails generate rswag:install
+```
 
 **Step 3:** You'll need some controllers/models to describe, which your application probably already has. If you need to make some, use the following scaffold command to add everything Rails related.
 

--- a/src/_guides/openapi/design-first-rails.md
+++ b/src/_guides/openapi/design-first-rails.md
@@ -9,6 +9,7 @@ Ruby on Rails developers are blessed with a bunch of great [OpenAPI](https://spe
 Instead of writing loads of code and sprinkling in some metadata later to create docs, the design-first workflow assumes you create the OpenAPI descriptions before writing any code at all. Once you have the OpenAPI description documents saved in your repository, you can leverage it at every step of the API lifecycle, to produce mock APIs for clients to test assumptions with, build client libraries without writing any code, make really effective contract testing, and even generate backend code to get the application teams started once the contract is all signed off.
 
 This guide is going to look at two specific parts of the API design-first workflow that are most helpful to documentation, and show how to set it up in Rails: request validation automatically, and contract testing responses.
+
 - [Getting OpenAPI \& Bump.sh Setup](#getting-openapi--bumpsh-setup)
 - [Request Validation powered by OpenAPI](#request-validation-powered-by-openapi)
 - [Contract Testing with OpenAPI](#contract-testing-with-openapi)

--- a/src/_guides/openapi/design-first-rails.md
+++ b/src/_guides/openapi/design-first-rails.md
@@ -40,16 +40,16 @@ Once Bump.sh is hooked up, let's look at how we'd teach a Rails API (new, or exi
 
 Instead of wasting loads of time writing out validation logic in dry or whatever other DSL, why not just point it at an existing OpenAPI description document and skip repeating yourself? You don't need to spend forever writing out that name is required, email is also required and an email address, date of birth is a date and optional... that's what your OpenAPI description already says, and because it's in a machine readable format you can just use it as code.
 
-1. Add the [openapi_first](https://rubygems.org/gems/openapi_first) gems to your `Gemfile`.
+**Step 1:** Add the [openapi_first](https://rubygems.org/gems/openapi_first) gems to your `Gemfile`.
 
   ```ruby
   # Gemfile
   gem 'openapi_first', '~> 1.0'
   ```
 
-2. Run `bundle install` in the CLI.
+**Step 2:** Run `bundle install` in the CLI.
 
-3. Add the request validation middleware to the Rails application config.
+**Step 3:** Add the request validation middleware to the Rails application config.
 
   ```ruby
   # config/application.rb
@@ -72,13 +72,13 @@ Instead of wasting loads of time writing out validation logic in dry or whatever
   end
   ```
 
-4. Start your server up and try it out! 
+**Step 4:** Start your server up and try it out! 
 
   ```
   $ rails s
   ```
   
-1. Now using your favourite HTTP client you can try interacting with your API, to see how it works. Presuming you've got an endpoint, if not quickly make some sample controller (or grab ours from the [sample code](https://github.com/bump-sh-examples/rails-design-first)) and make sure the model has some required properties. A basic test is to try sending a request that misses out a required property, to see if that allows the request through or fails it.
+**Step 5:** Now using your favourite HTTP client you can try interacting with your API, to see how it works. Presuming you've got an endpoint, if not quickly make some sample controller (or grab ours from the [sample code](https://github.com/bump-sh-examples/rails-design-first)) and make sure the model has some required properties. A basic test is to try sending a request that misses out a required property, to see if that allows the request through or fails it.
 
   ```
   $ curl -X POST http://localhost:3000/widgets -H "Content-Type: application/json" -d '{}'  | jq .
@@ -119,16 +119,16 @@ So long as you keep deploying OpenAPI changes to Bump using the CLI or GitHub Ac
 
 It can also power contract testing in your existing test suite, and [openapi_contracts](https://rubygems.org/gems/openapi_contracts) can help out.
 
-1. Add the openapi_first gems to your `Gemfile`.
+**Step 1:** Add the openapi_first gems to your `Gemfile`.
 
   ```ruby
   # Gemfile
   gem 'openapi_contracts'
   ```
 
-2. Run `bundle install` in the CLI.
+**Step 2:** Run `bundle install` in the CLI.
 
-3. Add this to `spec/rails_helper.rb` to let openapi_contracts know where your OpenAPI lives in the codebase. If this file does not exist make sure RSpec is setup and installed and run `rails generate rspec:install`.
+**Step 3:** Add this to `spec/rails_helper.rb` to let openapi_contracts know where your OpenAPI lives in the codebase. If this file does not exist make sure RSpec is setup and installed and run `rails generate rspec:install`.
 
   ```ruby
   # spec/rails_helper.rb
@@ -143,50 +143,51 @@ It can also power contract testing in your existing test suite, and [openapi_con
   ```
 
 
-4. The way openapi_contract works is by adding a single assertion that can be used in [Rails Request tests](). Learn more about request tests with [Rails and RSpec with this tutorial](https://medium.com/@qualitytechgirl/ruby-on-rails-testing-with-rspec-requests-92b09c8057a4), but basically it looks a bit like this. 
+**Step 4:** The way openapi_contract works is by adding a single assertion that can be used in [request tests](https://rspec.info/features/6-0/rspec-rails/request-specs/request-spec/). Learn more about request tests with [Rails and RSpec with this tutorial](https://medium.com/@qualitytechgirl/ruby-on-rails-testing-with-rspec-requests-92b09c8057a4), but basically it looks a bit like this. 
 
-  ```ruby
-  # spec/requests/widgets_spec.rb
+```ruby
+# spec/requests/widgets_spec.rb
 
-  require "rails_helper"
+require "rails_helper"
 
-  RSpec.describe 'widgets', type: :request do
-    
-    describe "GET /widgets" do
-      it 'responds with 200 and matches the doc' do
-        get '/widgets'
-        expect(response).to have_http_status(:ok)
-        expect(response).to match_openapi_doc(OPENAPI_DOC)
-      end
+RSpec.describe 'widgets', type: :request do
+  
+  describe "GET /widgets" do
+    it 'responds with 200 and matches the doc' do
+      get '/widgets'
+      expect(response).to have_http_status(:ok)
+      expect(response).to match_openapi_doc(OPENAPI_DOC)
     end
-
   end
-  ```
 
-  All the magic is happening in `expect(response).to match_openapi_doc(OPENAPI_DOC)`, where it's looking at the OpenAPI description, seeing which HTTP method and endpoint to look for, then comparing what it sees against the schema for the defined response. 
+end
+```
 
-  If you get a response back in a test for a status code that is not defined in OpenAPI it will let you know:
+All the magic is happening in `expect(response).to match_openapi_doc(OPENAPI_DOC)`, where it's looking at the OpenAPI description, seeing which HTTP method and endpoint to look for, then comparing what it sees against the schema for the defined response. 
+
+If you get a response back in a test for a status code that is not defined in OpenAPI it will let you know:
 
 
-  ```
-  Failures:
+```
+Failures:
 
-    1) widgets POST /widgets responds with 400 when invalid
-      Failure/Error: expect(response).to match_openapi_doc(OPENAPI_DOC)
-        * Undocumented response for "POST /widgets" with http status Bad Request (400)
-      # ./spec/requests/widgets_spec.rb:18:in `block (3 levels) in <top (required)>'
-  ```
-  
-  
-  Various other problems were noticed, like my documentation saying POST /widgets would return with a 201 and an empty body, but the API was returning the entire object of the resource that was just created for no reason.
+  1) widgets POST /widgets responds with 400 when invalid
+    Failure/Error: expect(response).to match_openapi_doc(OPENAPI_DOC)
+      * Undocumented response for "POST /widgets" with http status Bad Request (400)
+    # ./spec/requests/widgets_spec.rb:18:in `block (3 levels) in <top (required)>'
+```
 
-  ```
-   1) widgets POST /widgets responds with 201 when valid
-     Failure/Error: expect(response).to match_openapi_doc(OPENAPI_DOC)
-       * Expected empty response body
-     # ./spec/requests/widgets_spec.rb:17:in `block (3 levels) in <top (required)>'
+Various other problems were noticed, like my documentation saying POST /widgets would return with a 201 and an empty body, but the API was returning the entire object of the resource that was just created for no reason.
 
-  ```
+```
+  1) widgets POST /widgets responds with 201 when valid
+    Failure/Error: expect(response).to match_openapi_doc(OPENAPI_DOC)
+      * Expected empty response body
+    # ./spec/requests/widgets_spec.rb:17:in `block (3 levels) in <top (required)>'
+
+```
+
+Keep experimenting with your OpenAPI and code responses until you're happy with it all. See if you can break things, see if you can find uncovered endpoints, and keep making your code and OpenAPI better with every tweak.
 
 ## Sample Code
 


### PR DESCRIPTION
Sorry about this folks, I checked the merged guides and there's more formatting issues. I had fixed these in the laravel pulls but in an effort to keep PRs independent I reset them and forgot to apply the fixes in the right branch. 