### PR TITLE
styles: add tasklist and checkbox basic style

### DIFF
--- a/frontend/styles/atoms/input.css
+++ b/frontend/styles/atoms/input.css
@@ -6,6 +6,14 @@
   font-size: 0.875rem;
   height: var(--spacing-10);
   padding: var(--spacing-2) var(--spacing-3);
+
+  &[type="checkbox"] {
+    aspect-ratio: 1 / 1;
+    margin: 0;
+    margin-right: var(--spacing-2);
+    padding: 0;
+    height: var(--spacing-5);
+  }
 }
 
 :where(input):hover {

--- a/frontend/styles/components/tasklist.css
+++ b/frontend/styles/components/tasklist.css
@@ -1,0 +1,10 @@
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  list-style-type: none;
+
+  .task-list-item {
+    display: flex;
+  }
+}

--- a/frontend/styles/index.css
+++ b/frontend/styles/index.css
@@ -23,6 +23,7 @@
 
 @import "components/card.css";
 @import "components/search.css";
+@import "components/tasklist.css";
 @import "components/toc.css";
 @import "components/timeline.css";
 @import "components/update.css";


### PR DESCRIPTION
Seems like our markdown processor automatically turns checkbox lists into `task-list`s, which make them easy to style with the given classname.

I removed the bullet points from the list and gave checkboxes a smaller and square look.

![image](https://github.com/bump-sh/docs/assets/1301085/0e298137-93b7-4e1f-9e58-2f6e3ad6aaa0)
(don't mind the nav, it seems firefox screenshot feature doesn't handle blur)