### PR TITLE
fix: add redirections for links which are present in the product

### DIFF
--- a/src/_redirects
+++ b/src/_redirects
@@ -11,3 +11,6 @@ https://help.bump.sh/* https://docs.bump.sh/:splat 301!
 /help/doc-topics/ /help/enhance-documentation-content/topics/
 /help/custom-domains/ /help/customization-options/custom-domains/
 /help/quick-start/ /help/getting-started/
+/help/bump-cli /help/continuous-integration/cli/
+/help/github-action /help/continuous-integration/github-actions/
+/help/specifications-support /help/specification-support/


### PR DESCRIPTION
We have some dead links coming from bump.sh (both marketing page
/students and from the workspace for links to documentation about the
bump-cli).

This PR fixes those by adding redirections to the correct pages.