### PR TITLE
Update GH action URL

### DIFF
--- a/src/_guides/asyncapi/2024-03-25-asyncapi-first-event-driven-api.md
+++ b/src/_guides/asyncapi/2024-03-25-asyncapi-first-event-driven-api.md
@@ -223,7 +223,7 @@ The CLI will respond with an URL that, if visited, will let you visualize for a 
 
 When your AsyncAPI file is ready to be deployed, you can follow the simple steps of the [Getting Started](/help/getting-started/) to have your API documentation live and ready to share.
 
-You can also connect the Bump.sh CLI to CI/CD tools, and there is even a GitHub Action you can add to any project. Which will allow you to automatically track and inform about API changes and deploy new versions of your API, among other cool possibilities you can read about on the [Bump.sh page in GitHub marketplace](https://github.com/marketplace/actions/bump-sh)
+You can also connect the Bump.sh CLI to CI/CD tools, and there is even a GitHub Action you can add to any project. Which will allow you to automatically track and inform about API changes and deploy new versions of your API, among other cool possibilities you can read about on the [Bump.sh page in GitHub marketplace](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog)
 
 ## Conclusion
 

--- a/src/_guides/bump-sh-tutorials/2024-03-25-huma.md
+++ b/src/_guides/bump-sh-tutorials/2024-03-25-huma.md
@@ -140,7 +140,7 @@ go run . openapi
 go run . openapi > openapi.yaml
 ```
 
-Deploying to Bump.sh automatically through [GitHub Actions](https://github.com/marketplace/actions/bump-sh) now only involves running this command and pointing to the OpenAPI you created. This example will do both the deployment and the diff checking, but you can pick one or the other, or keep both.
+Deploying to Bump.sh automatically through [GitHub Actions](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog) now only involves running this command and pointing to the OpenAPI you created. This example will do both the deployment and the diff checking, but you can pick one or the other, or keep both.
 
 ```yaml
 name: Check & deploy API documentation
@@ -201,7 +201,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
 
-That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/help/getting-started/quick-start#customization-options). Check out the [Bump.sh GitHub Action](https://github.com/marketplace/actions/bump-sh) or other [continuous integration](/help/continuous-integration/) options.
+That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/help/getting-started/quick-start#customization-options). Check out the [Bump.sh GitHub Action](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog) or other [continuous integration](/help/continuous-integration/) options.
 
 ## Sample Code
 

--- a/src/_guides/openapi/2024-03-25-design-first-laravel-php.md
+++ b/src/_guides/openapi/2024-03-25-design-first-laravel-php.md
@@ -35,7 +35,7 @@ $ bump deploy api/openapi.yaml \
 * Your new documentation version will soon be ready at https://bump.sh/hub/code-samples/doc/laravel-design-first
 ```
 
-Instead of using the [CLI](https://github.com/bump-sh/cli#bump-deploy-file) you could use [GitHub Actions](https://github.com/marketplace/actions/bump-sh), or a bunch of other [Continuous Integration](/help/continuous-integration/).
+Instead of using the [CLI](https://github.com/bump-sh/cli#bump-deploy-file) you could use [GitHub Actions](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog), or a bunch of other [Continuous Integration](/help/continuous-integration/).
 
 Once Bump.sh is hooked up, let's look at how we'd teach a Laravel API (new, or existing) to be able to handle request validation for us.
 

--- a/src/_guides/openapi/2024-03-25-design-first-rails.md
+++ b/src/_guides/openapi/2024-03-25-design-first-rails.md
@@ -33,7 +33,7 @@ $ bump deploy api/openapi.yaml \
 * Your new documentation version will soon be ready at https://bump.sh/bump-examples/hub/code-samples/doc/rails-design-first
 ```
 
-Instead of using the [CLI](https://github.com/bump-sh/cli#bump-deploy-file) you could use [GitHub Actions](https://github.com/marketplace/actions/bump-sh), or a bunch of other [Continuous Integration](/help/continuous-integration/).
+Instead of using the [CLI](https://github.com/bump-sh/cli#bump-deploy-file) you could use [GitHub Actions](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog), or a bunch of other [Continuous Integration](/help/continuous-integration/).
 
 Once Bump.sh is hooked up, let's look at how we'd teach a Rails API (new, or existing) to be able to handle request validation for us.
 

--- a/src/_help/continuous-integration/cli.md
+++ b/src/_help/continuous-integration/cli.md
@@ -15,7 +15,7 @@ The Bump.sh CLI is used to interact with your API documentation or hubs hosted o
 
 The Bump.sh CLI is a node package currently distributed via NPM. This means you must have the Node v14+ interpreter installed on your computer or CI servers.
 
-_If you are looking to use Bump.sh in a continuous integration environment you might be interested by [our Github Action](https://github.com/marketplace/actions/bump-sh)._
+_If you are looking to use Bump.sh in a continuous integration environment you might be interested by [our Github Action](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog)._
 
 > You can download a standalone package directly from the latest
 > Github release assets if you don’t use Node.


### PR DESCRIPTION
We changed the name (again) in the latest release
https://github.com/bump-sh/github-action/releases/tag/v1.1.10

Let's change the GH action URL everywhere it's used.

Follow-up to https://github.com/bump-sh/docs/pull/235