### PR TITLE
Add UTM tags to CTA

### DIFF
--- a/src/_components/guides/sidebar.erb
+++ b/src/_components/guides/sidebar.erb
@@ -13,6 +13,6 @@
       <dd><%= @update %></dd>
     </dl>
   <%= render Shared::EditOnGithub.new(relative_path: @relative_path) %>
-  <%= render Shared::BumpCta.new %>
+  <%= render Shared::BumpCta.new(slug: @slug) %>
   </aside>
 </guide-sidebar>

--- a/src/_components/guides/sidebar.rb
+++ b/src/_components/guides/sidebar.rb
@@ -6,5 +6,6 @@ class Guides::Sidebar < Bridgetown::Component
     @tags = @data.tags
     @update = @data.date.strftime("%B %d, %Y")
     @relative_path = relative_path
+    @slug = @data.slug
   end
 end

--- a/src/_components/shared/bump_cta.erb
+++ b/src/_components/shared/bump_cta.erb
@@ -1,4 +1,4 @@
 <bump-cta>
   <p><strong>Bump.sh</strong>, an API doc platform for tech writers & engineers</p>
-  <a class="button" href="https://bump.sh/users/sign_up">Get started for free <%= svg "images/icons/arrow-right.svg" %></a>
+  <a class="button" href="https://bump.sh/users/sign_up?utm_source=content-hub&utm_medium=cta">Get started for free <%= svg "images/icons/arrow-right.svg" %></a>
 </bump-cta>

--- a/src/_components/shared/bump_cta.erb
+++ b/src/_components/shared/bump_cta.erb
@@ -1,4 +1,4 @@
 <bump-cta>
   <p><strong>Bump.sh</strong>, an API doc platform for tech writers & engineers</p>
-  <a class="button" href="https://bump.sh/users/sign_up?utm_source=content-hub&utm_medium=cta">Get started for free <%= svg "images/icons/arrow-right.svg" %></a>
+  <a class="button" href="<%= "https://bump.sh/users/sign_up?utm_source=content-hub&utm_medium=cta&utm_content=#{@slug}" %>">Get started for free <%= svg "images/icons/arrow-right.svg" %></a>
 </bump-cta>

--- a/src/_components/shared/bump_cta.rb
+++ b/src/_components/shared/bump_cta.rb
@@ -1,2 +1,5 @@
 class Shared::BumpCta < Bridgetown::Component
+  def initialize(slug:)
+    @slug = slug
+  end
 end


### PR DESCRIPTION
@thimy is it possible to dynamically add a `utm_content` that would take the file name (minus the .md extension) of the guide from which the CTA is clicked on?