### PR TITLE
First batch of link fixes

### DIFF
--- a/src/_guides/bump-sh-tutorials/api-platform.md
+++ b/src/_guides/bump-sh-tutorials/api-platform.md
@@ -31,7 +31,7 @@ The following assumes your local machine is configured with PHP and API Platform
     --token my-documentation-token
   ```
 
-That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/help/getting-started/quick-start#customization-options).
+That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/help/customization-options).
 
 ## Enriching documents
 

--- a/src/_guides/bump-sh-tutorials/fastapi.md
+++ b/src/_guides/bump-sh-tutorials/fastapi.md
@@ -33,7 +33,7 @@ The following assumes your local machine is configured with Python and FastAPI, 
     --token my-documentation-token
   ```
 
-That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/help/getting-started/quick-start#customization-options).
+That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/help/customization-options/).
 
 ## Enriching documents
 

--- a/src/_guides/bump-sh-tutorials/huma.md
+++ b/src/_guides/bump-sh-tutorials/huma.md
@@ -202,7 +202,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
 
-That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/help/getting-started/quick-start#customization-options). Check out the [Bump.sh GitHub Action](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog) or other [continuous integration](/help/continuous-integration/) options.
+That's it! Enjoy the comfort of Bump.sh to browse through your API doc, and [customize it to your needs](/help/customization-options). Check out the [Bump.sh GitHub Action](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog) or other [continuous integration](/help/continuous-integration/) options.
 
 ## Sample Code
 

--- a/src/_guides/openapi/code-first-laravel.md
+++ b/src/_guides/openapi/code-first-laravel.md
@@ -352,4 +352,4 @@ There is a lot more work to be done until 100% of your API is covered, but you c
 
 ## Sample Code
 
-The sample code for this guide is published on GitHub so you can try that if you're having trouble adding it to your application: [laravel-code-first](https://github.com/bump-sh/laravel-code-first), and the [deployed documentation](https://bump.sh/bump-examples/hub/code-samples/doc/laravel-code-first) is over here.
+The sample code for this guide is published on GitHub so you can try that if you're having trouble adding it to your application: [laravel-code-first](https://github.com/bump-sh/laravel-api-with-documentation), and the [deployed documentation](https://bump.sh/bump-examples/hub/code-samples/doc/laravel-code-first) is over here.

--- a/src/_guides/openapi/openapi-moonwalk.md
+++ b/src/_guides/openapi/openapi-moonwalk.md
@@ -1,7 +1,7 @@
 ---
 title: 'OpenAPI v4.0 (A.K.A "Project Moonwalk")'
 authors: phil
-canonical_url: https://bump.sh/blog/openapi-moonwalk
+canonical_url: https://bump.sh/blog/openapi-v4-moonwalk
 excerpt: What is coming next for OpenAPI, as v4.0 of the OpenAPI Specification gets closer to being released? What major changes are coming, how easy will it be to upgrade, and how do tooling companies feel about it?
 date: 2024-04-15
 ---

--- a/src/_help/continuous-integration/cli.md
+++ b/src/_help/continuous-integration/cli.md
@@ -156,7 +156,7 @@ Please check `bump deploy --help` for more usage details.
 
 ### `bump diff [FILE]`
 
-_If you want to receive automatic `bump diff` results on your Github Pull Requests you might be interested by [our Github Action](https://github.com/marketplace/actions/api-documentation-on-bump#api-diff-on-pull-requests) diff command._
+_If you want to receive automatic `bump diff` results on your Github Pull Requests you might be interested by [our Github Action](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog#deploy-documentation--diff-on-pull-requests) diff command._
 
 #### Public API diffs
 

--- a/src/_product-updates/2020-02-20-introducing-our-github-action.md
+++ b/src/_product-updates/2020-02-20-introducing-our-github-action.md
@@ -3,7 +3,7 @@ title: Introducing our GitHub action
 tags: [New feature]
 ---
 
-Deploying your API documentation has never been so simple if you are using GitHub. We have just released [our GitHub action](https://github.com/marketplace/actions/api-documentation-on-bump), which lets you super easily control when and how you want to deploy your doc.
+Deploying your API documentation has never been so simple if you are using GitHub. We have just released [our GitHub action](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog), which lets you super easily control when and how you want to deploy your doc.
 
 All you have to do is configuring your workflow:
 

--- a/src/_product-updates/2021-02-04-hello-openapi-webhooks.md
+++ b/src/_product-updates/2021-02-04-hello-openapi-webhooks.md
@@ -7,6 +7,6 @@ tags: [New]
 
 [OpenAPI 3.1](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md) has been released today. Some important changes are coming with this new version. Above all, the greatest improvement is the support of `webhooks`, at the same first level than `paths`.
 
-We are glad to announce today that webhooks are now supported by Bump, as you can see in this [live example](https://bump.sh/doc/webhook-example).
+We are glad to announce today that webhooks are now supported by Bump, as you can see in this [live example](https://bump.sh/bump/doc/webhook-example).
 
 We hope you'll enjoy this new feature, don't hesitate to have a look to our [technical documentation](/help/specification-support/openapi-support/webhooks/) if necessary.

--- a/src/_product-updates/2021-03-16-global-support-of-external-references.md
+++ b/src/_product-updates/2021-03-16-global-support-of-external-references.md
@@ -8,7 +8,7 @@ As your API grows, your specification becomes more and more complex. At some poi
 We have just released full external references support  by updating:
 * our web app
 * our CLI ([version 0.7 is out](https://github.com/bump-sh/bump-cli/releases/tag/v0.7.0))
-* our GitHub action ([version 0.2 is out](https://github.com/marketplace/actions/api-documentation-on-bump))
+* our GitHub action ([version 0.2 is out](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog))
 
 Now, no matter the channel you use to deploy a specification, Bump will resolve all references (when possible) and import their content into your documentation.
 

--- a/src/_product-updates/2021-11-14-bump-diff-navigation.md
+++ b/src/_product-updates/2021-11-14-bump-diff-navigation.md
@@ -8,5 +8,3 @@ tags: [Improvement]
 Jump from change to change! No need to scroll anymore to see the latest changes in your documentation diff.
 
 ![diff-navigation.gif](/images/changelog/diff-navigation.gif)
-
-See it in action: [https://docs.canopyservicing.com/changes/fbcf9592-a369-4f17-9adb-410d48e3ff98](https://docs.canopyservicing.com/changes/fbcf9592-a369-4f17-9adb-410d48e3ff98)

--- a/src/_product-updates/2022-09-05-automated-image-generation.md
+++ b/src/_product-updates/2022-09-05-automated-image-generation.md
@@ -8,6 +8,6 @@ We recently released a new social network feature, that helps you create beautif
 
 You can now upload your own image or leave the work to us to generate a nice one. Sharing your documentation link on social networks will now display your own visual, making it more appealing.
 
-Find out more in our [Help Center](/help/meta-images/)!
+Find out more in our [Help Center](/help/customization-options/color-logo-meta-images/)!
 
 ![metaimage-forto.png](/images/changelog/metaimage-forto.png)

--- a/src/_redirects
+++ b/src/_redirects
@@ -13,4 +13,7 @@ https://help.bump.sh/* https://docs.bump.sh/:splat 301!
 /help/quick-start/ /help/getting-started/
 /help/bump-cli /help/continuous-integration/cli/
 /help/github-action /help/continuous-integration/github-actions/
-/help/specifications-support /help/specification-support/
+/help/specifications-support/ /help/specification-support/
+/help/meta-images/ /help/customization-options/color-logo-meta-images/
+/continuous-integration/github-actions/ /help/continuous-integration/github-actions/
+/bump-cli/ /help/continuous-integration/cli/


### PR DESCRIPTION
Here's a first batch of link fixes for the content hub.

From the AHREF report, I didn't quite understand why some links were considered non-functional. The redirection file points correctly to the resources so I tested an alternative here, though I'm not sure it works completely.

There are more fixes needed on other repositories and there might be one or two missing here; I need to review them quickly.