### PR TITLE
cta: edit text and make button content centered

### DIFF
--- a/src/_components/shared/bump_cta.css
+++ b/src/_components/shared/bump_cta.css
@@ -16,6 +16,7 @@ bump-cta {
     --button-color-hover: var(--gradient-blue);
     color: var(--white);
     height: auto;
+    justify-content: center;
     transition: all ease-in 0.2s;
 
     &:hover {

--- a/src/_components/shared/bump_cta.erb
+++ b/src/_components/shared/bump_cta.erb
@@ -1,4 +1,4 @@
 <bump-cta>
-  <p><strong>Bump.sh</strong>, an API doc platform for tech writers & engineers</p>
+  <p><strong>Bump.sh</strong>, the API doc platform for Tech Writers & Engineers</p>
   <a class="button" href="<%= "https://bump.sh/users/sign_up?utm_source=content-hub&utm_medium=cta&utm_content=#{@slug}" %>">Get started for free <%= svg "images/icons/arrow-right.svg" %></a>
 </bump-cta>


### PR DESCRIPTION
Changed the prompt, added caps and centered button content. 
<img width="250" alt="image" src="https://github.com/user-attachments/assets/2f27d367-8ffb-440a-a8f8-58a605aedde4">
