### PR TITLE
component: prev/next navigation

### DIFF
--- a/src/_components/shared/page_navigation.css
+++ b/src/_components/shared/page_navigation.css
@@ -1,0 +1,23 @@
+page-navigation {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-6);
+  justify-content: end;
+  margin-block: var(--spacing-28) var(--spacing-4);
+
+  a {
+    color: var(--text-color);
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-3);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .previous svg {
+    rotate: 180deg;
+  }
+}

--- a/src/_components/shared/page_navigation.erb
+++ b/src/_components/shared/page_navigation.erb
@@ -1,0 +1,14 @@
+<page-navigation>
+  <% if @previous.present? %>
+    <%= link_to @previous.resource.relative_url, class: "previous" do %>
+      <%= svg "images/icons/arrow-right.svg" %>
+      <%= @previous.label %>
+    <% end %>
+  <% end %>
+  <% if @next.present? %>
+    <%= link_to @next.resource.relative_url do %>
+      <%= @next.label %>
+      <%= svg "images/icons/arrow-right.svg" %>
+    <% end %>
+  <% end %>
+</page-navigation>

--- a/src/_components/shared/page_navigation.rb
+++ b/src/_components/shared/page_navigation.rb
@@ -1,0 +1,27 @@
+class Shared::PageNavigation < Bridgetown::Component
+  def initialize(entries:, current:)
+    @entries = entries
+    @current = current
+
+    set_links
+  end
+
+  def set_links
+    pages = []
+    get_resources(@entries, pages)
+    index = pages.find_index do |resource|
+      resource.resource == @current if resource.resource.present?
+    end
+    if index.present?
+      @previous = pages[index - 1] if index != 0
+      @next = pages[index + 1] if index != pages.size - 1
+    end
+  end
+
+  def get_resources(entries, pages)
+    entries.each do |entry|
+      pages << entry if entry.resource.present?
+      get_resources(entry.items, pages) if entry.items.present?
+    end
+  end
+end


### PR DESCRIPTION
This component takes the list of resources of a collection, creates a flat array of all the resources to find the previous and next pages to display below a post.

It should be integrated in the upcoming OpenAPI guides and will look like this:
![image](https://github.com/user-attachments/assets/204f31e4-f613-4744-bc96-9fd8da1f29c5)
