### PR TITLE
specification guides: exclude from listing

### DIFF
--- a/src/_guides/openapi/specification/_defaults.yml
+++ b/src/_guides/openapi/specification/_defaults.yml
@@ -5,3 +5,4 @@ skip_listing: true
 display_authors: true
 display_pagination: true
 display_cta: true
+exclude_from_pagination: true


### PR DESCRIPTION
Added an option to exclude specification guides from being listed in the OpenAPI list.