### PR TITLE
Canonical URL for OpenAPI spec generation with Typespec

### DIFF
--- a/src/_guides/openapi/accelerating-youropenapi-spec-generation-with-typespec.md
+++ b/src/_guides/openapi/accelerating-youropenapi-spec-generation-with-typespec.md
@@ -2,6 +2,7 @@
 title: Accelerating your OpenAPI Spec Generation with TypeSpec 
 authors: james
 canonical_url: https://bump.sh/blog/accelerating-your-openapi-spec-generation-with-typespec
+date: 2024-10-07
 excerpt: Let's explore TypeSpec, an alternative to the OpenAPI Specification for capturing the details of your API definition, with support for OpenAPI, gRPC, and JSON Schema output formats.
 ---
 

--- a/src/_guides/openapi/accelerating-youropenapi-spec-generation-with-typespec.md
+++ b/src/_guides/openapi/accelerating-youropenapi-spec-generation-with-typespec.md
@@ -1,6 +1,7 @@
 ---
 title: Accelerating your OpenAPI Spec Generation with TypeSpec 
 authors: james
+canonical_url: https://bump.sh/blog/accelerating-your-openapi-spec-generation-with-typespec
 excerpt: Let's explore TypeSpec, an alternative to the OpenAPI Specification for capturing the details of your API definition, with support for OpenAPI, gRPC, and JSON Schema output formats.
 ---
 


### PR DESCRIPTION
Added the missing canonical url to this article.