### PR TITLE
Display CTA component with a slot

### DIFF
--- a/src/_components/shared/sidebar.css
+++ b/src/_components/shared/sidebar.css
@@ -43,6 +43,10 @@ side-bar {
     gap: var(--spacing-1);
   }
 
+  bump-cta {
+    margin-block-start: var(--spacing-8);
+  }
+
   .sidebar-sublist {
     border-left: var(--border-default);
     display: none;

--- a/src/_components/shared/sidebar.erb
+++ b/src/_components/shared/sidebar.erb
@@ -11,5 +11,6 @@
         </li>
       <% end %>
     </ul>
+    <%= slotted :after %>
   </aside>
 </side-bar>

--- a/src/_guides/openapi/specification/_defaults.yml
+++ b/src/_guides/openapi/specification/_defaults.yml
@@ -6,3 +6,4 @@ display_authors: true
 display_pagination: true
 display_cta: true
 exclude_from_pagination: true
+slug: openapi-specification

--- a/src/_layouts/documentation.erb
+++ b/src/_layouts/documentation.erb
@@ -12,9 +12,9 @@ layout: application
       </h1>
     <% end %>
   <% end %>
-  <% if resource.data.sidebar_title.present? %>
+  <% if resource.data.display_cta.present? %>
     <% sidebar.slot :after do %>
-      <%= render Shared::BumpCta.new(slug: site.data.slug) %>
+      <%= render Shared::BumpCta.new(slug: resource.data.slug) %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Purpose of this PR is to display the CTA button in guides section 'OpenAPI specification'.

I noticed that component `Shared::BumpCta` was already included in layout `_documentation.erb`, as a slot named `:after` in component `Shared::Sidebar`, but it was not displayed.

What is done in this PR:
- change condition to display this component: favor ready-to-use boolean `resource.data.display_cta`

- render the slot in the component, with `<%= slotted :after %>`

- add basic CSS to keep space between this CTA and the sidebar links 😇 (no dinguerie I swear!)

- set data.slug to 'openapi-specification', used as `utm_content`.

ℹ️  Data `display_cta` is responsible to display the BumpCta component. We would need to change value to false where it's not necessary.

Now:
<img width="1378" alt="image" src="https://github.com/user-attachments/assets/51daf3cf-1da6-44c9-a789-f2b155cfccdb" />

---

context: [Slack discussion](https://itducks.slack.com/archives/C01DP38BRTL/p1742550228070939)
