### PR TITLE
Fix share and highlight URL

### DIFF
--- a/src/_product-updates/2021-09-11-share-and-highlight-anything-inside-your-api-documentation.md
+++ b/src/_product-updates/2021-09-11-share-and-highlight-anything-inside-your-api-documentation.md
@@ -10,4 +10,4 @@ Thanks to this new feature, you can now share and highlight anything in your API
 
 ![share_highlight.gif](/images/changelog/share_highlight.gif)
 
-Give it a try: [https://developers.bump.sh/#post-previews-body](https://developers.bump.sh/#post-previews-body)
+Give it a try: [https://developers.bump.sh/operation/operation-post-previews](https://developers.bump.sh/operation/operation-post-previews)


### PR DESCRIPTION
It was no longer pointing to the correct doc part