### PR TITLE
blog: small typo and suggestion on multiple git branch workflow

### DIFF
--- a/src/_guides/bump-sh-tutorials/documenting-multiple-api-versions.md
+++ b/src/_guides/bump-sh-tutorials/documenting-multiple-api-versions.md
@@ -6,17 +6,17 @@ excerpt: When you release a new version of an API you’re going to need to keep
 date: 2025-05-13
 ---
 
-Versioning an API can be incredibly difficult, but working out how to handle documentation for multiple API versions can be even more of a challenge. When you release a new version of an API you’re going to need to keep the old one around for a while, and manage it as its own project until it can be retired. Thankfully Bump.sh makes it as simple and flexible as you could hope for. 
+Versioning an API can be incredibly difficult, but working out how to handle documentation for multiple API versions can be even more of a challenge. When you release a new version of an API you’re going to need to keep the old one around for a while, and manage it as its own project until it can be retired. Thankfully Bump.sh makes it as simple and flexible as you could hope for.
 
 ## Different workflows
 
-First of all, where and how is the API source code stored? 
+First of all, where and how is the API source code stored?
 
 - one Git repository for each API version
 - one Git branch for each API version
 - one Git repository for all the API versions (monorepo)
 
-It's best practice to keep the API descriptions (e.g.: `openapi.yaml`) with the API source code, so whichever of the above you're doing will work out just fine. If you're generating OpenAPI or AsyncAPI from source code, that'll work out just fine too. 
+It's best practice to keep the API descriptions (e.g.: `openapi.yaml`) with the API source code, so whichever of the above you're doing will work out just fine. If you're generating OpenAPI or AsyncAPI from source code, that'll work out just fine too.
 
 Let's look at how API documentation version management works with Bump.sh, and walk through a few of these scenarios so you can get things set up however you happen to work.
 
@@ -73,7 +73,7 @@ jobs:
         with:
           doc: <your-doc-id-or-slug>
           token: ${{secrets.BUMP_TOKEN}}
-          file: src/v3/api/openapi.yaml
+          file: src/v2/api/openapi.yaml
           branch: v2-legacy
 
       - name: Deploy API v3 documentation
@@ -87,24 +87,41 @@ jobs:
 
 ### Example: One Git branch per API version
 
-This setup involves one GitHub repository. Each version of the API is in its own
-Git branch, a `v2` and `v3`. In this instance, you could use GitHub Actions,
-with different actions in each branch.
+This setup involves one GitHub repository. Each version of the API is
+in its own Git branch, a `v2` and `v3`. In this instance, you could
+use a GitHub Action, that gets triggered on each of the corresponding
+branch. For more flexibility between the Git branch and the Bump.sh
+target file & branch, we've detailed below configuration mapping that
+you will need to adapt to your needs.
 
-In the `v2` Git branch:
+The workflow file would look like this in both Git branches:
 
 ```yaml
 # .github/workflows/bump.yml
-name: Deploy API documentation
+name: Deploy API documentation pushes
 on:
   push:
-    branches: [v2]
+    branches: [v2, v3]
 
 jobs:
   deploy-doc:
-    if: ${{ github.event_name == 'push' }}
     name: Deploy API documentation on Bump.sh
     runs-on: ubuntu-latest
+    env:
+      TARGET_BUMP_BRANCH: >
+        ${{
+          fromJson('{
+            "v3": "v3",
+            "v2": "v2-legacy"
+          }')[github.ref_name]
+        }}
+      SOURCE_FILE: >
+        ${{
+          fromJson('{
+            "v3": "openapi.yaml",
+            "v2": "legacy/directory/structure/swagger.yaml"
+          }')[github.ref_name]
+        }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -114,58 +131,13 @@ jobs:
         with:
           doc: <your-doc-id-or-slug>
           token: ${{secrets.BUMP_TOKEN}}
-          file: openapi.yaml
-          branch: v2-legacy
-```
-
-Commit, push, switch to the v3 branch, and merge (or grab just that workflow from v2 with restore):
-
-```shell
-git add .github/workflows/bump.yml
-git commit -m "docs: deploy v2 docs to bump"
-git push origin v2
-git checkout v3
-git restore --source=v2 .github/workflows/bump.yml
-```
-
-Now we can modify mentions of v2 to v3.
-
-```yaml
-# .github/workflows/bump.yml
-name: Deploy API documentation
-on:
-  push:
-    branches: [v3]
-
-jobs:
-  deploy-doc:
-    if: ${{ github.event_name == 'push' }}
-    name: Deploy API documentation on Bump.sh
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Deploy API documentation
-        uses: bump-sh/github-action@v1
-        with:
-          doc: <your-doc-id-or-slug>
-          token: ${{secrets.BUMP_TOKEN}}
-          file: openapi.yaml
-          branch: v3
-```
-
-Lets commit that and push it up to get both the v2 and v3 branches doing their thing.
-
-```shell
-git add .github/workflows/bump.yml
-git commit -m "docs: deploy v3 docs to bump"
-git push origin v3
+          file: ${{env.SOURCE_FILE}}
+          branch: ${{env.TARGET_BUMP_BRANCH}}
 ```
 
 ### Example: One repository for each API version
 
-This would look exactly the same as the previous example just pushing the workflows to two different repos instead of two different branches.
+This would look exactly the same as the previous example just pushing the workflow file to two different repos instead of two different branches. You would also need to adapt the branch name targets in the workflow file to align with the branches you use in each of the repository.
 
 ## Branch names
 
@@ -173,15 +145,15 @@ The branch names are important, and should be chosen carefully. The default bran
 
 Some API maintainers decide to name branches after major versions like v1, v2, v3. Some maintainers prefer branching based on release dates, especially when using [API evolution](https://apisyouwonthate.com/blog/api-evolution-for-rest-http-apis/) or date-based versions.
 
-Some API maintainers prefer to use terms like "beta" and "next" for their branches, which can be useful when the API is in a state of flux and the version numbers are not yet stable. 
+Some API maintainers prefer to use terms like "beta" and "next" for their branches, which can be useful when the API is in a state of flux and the version numbers are not yet stable.
 
 ## Deprecating old API versions
 
-When a new API version is created, and you create a new Bump.sh branch for the API documentation to match, at some point you will want new users to start using it. 
+When a new API version is created, and you create a new Bump.sh branch for the API documentation to match, at some point you will want new users to start using it.
 
-Announcements to users by email are a common soft-touch start, letting users know all the brilliant new functionality available in the new version of the API so they want to go and upgrade, but that won't get them all, and we also want to make sure new users aren't picking up the old version. 
+Announcements to users by email are a common soft-touch start, letting users know all the brilliant new functionality available in the new version of the API so they want to go and upgrade, but that won't get them all, and we also want to make sure new users aren't picking up the old version.
 
-The "carrot" of dangling a new shiny default version works best when deployed alongside a stick, and for API versioning that stick is deprecation. 
+The "carrot" of dangling a new shiny default version works best when deployed alongside a stick, and for API versioning that stick is deprecation.
 
 The basic premise of deprecation for APIs is giving people a heads up that an operation is going away and is best avoided. This would make a new API user think twice about using that operation, or that entire version if all the operations are deprecated, and helps point them towards the new version.
 


### PR DESCRIPTION
this commit contains two things:
- one typo fix in the multi file in same repo example
- suggestion to use a single workflow for the multi branches repo example