### PR TITLE
Help Center: introducing x-metaTags

### DIFF
--- a/src/_data/sidebar.yml
+++ b/src/_data/sidebar.yml
@@ -124,10 +124,6 @@ help:
     items:
       - label: Common elements
         items:
-          - label: Badges
-            link: /specification-support/doc-badges/
-          - label: Custom meta tags
-            link: /specification-support/meta-tags/
           - label: JSON Schema
             link: /specification-support/json-schema/
           - label: Multiple servers
@@ -140,6 +136,10 @@ help:
             link: /specification-support/references/
           - label: Specification extensions
             link: /specification-support/extensions/
+          - label: Badges
+            link: /specification-support/doc-badges/
+          - label: Custom meta tags
+            link: /specification-support/meta-tags/
       - label: OpenAPI support
         link: /specification-support/openapi-support/
         items:

--- a/src/_data/sidebar.yml
+++ b/src/_data/sidebar.yml
@@ -124,20 +124,22 @@ help:
     items:
       - label: Common elements
         items:
+          - label: Badges
+            link: /specification-support/doc-badges/
+          - label: Custom meta tags
+            link: /specification-support/meta-tags/
           - label: JSON Schema
             link: /specification-support/json-schema/
           - label: Multiple servers
             link: /specification-support/multiple-servers/
+          - label: Overlays
+            link: /specification-support/overlays/
           - label: Polymorphism
             link: /specification-support/polymorphism/
           - label: References
             link: /specification-support/references/
           - label: Specification extensions
             link: /specification-support/extensions/
-          - label: Badges
-            link: /specification-support/doc-badges/
-          - label: Overlays
-            link: /specification-support/overlays/
       - label: OpenAPI support
         link: /specification-support/openapi-support/
         items:

--- a/src/_data/sidebars/help.yml
+++ b/src/_data/sidebars/help.yml
@@ -132,20 +132,22 @@ resources:
     items:
       - label: Common elements
         items:
+          - label: Badges
+            link: /specification-support/doc-badges/
+          - label: Custom meta tags
+            link: /specification-support/meta-tags/
           - label: JSON Schema
             link: /specification-support/json-schema/
           - label: Multiple servers
             link: /specification-support/multiple-servers/
+          - label: Overlays
+            link: /specification-support/overlays/
           - label: Polymorphism
             link: /specification-support/polymorphism/
           - label: References
             link: /specification-support/references/
           - label: Specification extensions
             link: /specification-support/extensions/
-          - label: Badges
-            link: /specification-support/doc-badges/
-          - label: Overlays
-            link: /specification-support/overlays/
       - label: OpenAPI support
         link: /specification-support/openapi-support/
         items:

--- a/src/_data/sidebars/help.yml
+++ b/src/_data/sidebars/help.yml
@@ -132,10 +132,6 @@ resources:
     items:
       - label: Common elements
         items:
-          - label: Badges
-            link: /specification-support/doc-badges/
-          - label: Custom meta tags
-            link: /specification-support/meta-tags/
           - label: JSON Schema
             link: /specification-support/json-schema/
           - label: Multiple servers
@@ -148,6 +144,10 @@ resources:
             link: /specification-support/references/
           - label: Specification extensions
             link: /specification-support/extensions/
+          - label: Badges
+            link: /specification-support/doc-badges/
+          - label: Custom meta tags
+            link: /specification-support/meta-tags/
       - label: OpenAPI support
         link: /specification-support/openapi-support/
         items:

--- a/src/_help/specification-support/extensions.md
+++ b/src/_help/specification-support/extensions.md
@@ -34,3 +34,7 @@ This custom property allows you to add a button to your documentation that enabl
 ## Add links to external resources (`x-externalLinks`)
 
 This custom property lets you add links to the navigation bar of your documentation, redirecting users to external resources. Find out more in our [dedicated section](/help/publish-documentation/external-links).
+
+## Add custom meta tags (`x-metaTags`)
+
+This custom property lets you add custom meta tags in the <head> tag of your documentation pages. Find out more in our [dedicated section](/help/specification-support/meta-tags).

--- a/src/_help/specification-support/extensions.md
+++ b/src/_help/specification-support/extensions.md
@@ -37,4 +37,4 @@ This custom property lets you add links to the navigation bar of your documentat
 
 ## Add custom meta tags (`x-metaTags`)
 
-This custom property lets you add custom meta tags in the <head> tag of your documentation pages. Find out more in our [dedicated section](/help/specification-support/meta-tags).
+This custom property lets you add custom meta tags in the `<head>` tag of your documentation pages. Find out more in our [dedicated section](/help/specification-support/meta-tags).

--- a/src/_help/specification-support/meta-tags.md
+++ b/src/_help/specification-support/meta-tags.md
@@ -5,15 +5,23 @@ title: Custom meta tags
 - TOC
 {:toc}
 
-The x-metaTags extension allows to add `meta` tags to the `head` of a documentation page. For example, to enhance your own global search with more precise filtering through facets, thanks to custom meta tags retrieved by your internal crawler.
+Add custom `meta` tags to the `head` of your documentation pages with the `x-metaTags` extension. It can be used, for example, to improve your own global search with more precise filtering through facets, thanks to customized meta tags retrieved by your internal crawler.
 
-`x-metaTags` can be added at different levels: root, topic, tag ([when grouping by tag](/help/customization-options/operations-navigation/#group-operations-by-tag)), operation, webhook, message, ...
-
-Tags added to the root of the API definition file will be added to every page of the documentation. Tags added at any other level will only be added to the corresponding pages.
+`x-metaTags` can be added at different levels: 
+- root, 
+- topic, 
+- operation, 
+- webhook, 
+- message, 
+- binding, 
+- tag ([when the grouping mode is set to "Group by tag"](/help/customization-options/operations-navigation/#group-operations-by-tag)).
 
 Each object inside the `x-metaTags` array requires two elements:
 - `name` : the value that will be given to the `name` attribute,
 - `content` : the value that will be given to the `content` attribute.
+
+> Tags added to the root of the API definition file will be added to every page of the documentation. Tags added to any other level will only be added to the corresponding pages.
+{: .info}
 
 ## Example
 Here's an example of `x-metaTags` added to the root of the API definition and to an operation.

--- a/src/_help/specification-support/meta-tags.md
+++ b/src/_help/specification-support/meta-tags.md
@@ -1,0 +1,52 @@
+---
+title: Custom meta tags
+---
+
+- TOC
+{:toc}
+
+The x-metaTags extension allows to add `meta` tags to the `head` of a documentation page.
+
+`x-metaTags` can be added at different levels: root, topic, tag ([when grouping by tag](/help/customization-options/operations-navigation/#group-operations-by-tag)), operation, webhook, ...
+
+Tags added to the root of the API definition file will be added to every page of the documentation. Tags added at any other level will only be added to the corresponding pages.
+
+Each object inside the `x-metaTags` array requires two elements:
+- `name` : the value that will be given to the `name` attribute,
+- `content` : the value that will be given to the `content` attribute.
+
+## Example
+Here's an example of `x-metaTags` added to the root of the API definition and to an operation.
+
+**Adding the x-metaTags in the API definition file**
+```yaml
+x-metaTags:
+  - name: First root tag
+    content: First root tag content
+  - name: Second root tag
+    content: Second root tag content
+paths:
+  /user:
+    post:
+      x-metaTags:
+      - name: Operation tag
+        content: Operation tag content
+```
+
+**Impact on the <head> if the loaded documentation page is the root of the API documentation**
+```html
+<head>
+  <meta name="First root tag" content="First root tag content" />
+  <meta name="Second root tag" content="Second root tag content" />
+</head>
+```
+
+**Impact on the `<head>` if the loaded documentation page is the POST /user operation**
+```html
+<head>
+  <meta name="First root tag" content="First root tag content" />
+  <meta name="Second root tag" content="Second root tag content" />
+  <meta name="Operation tag" content="Operation tag content" />
+
+</head>
+```

--- a/src/_help/specification-support/meta-tags.md
+++ b/src/_help/specification-support/meta-tags.md
@@ -7,7 +7,7 @@ title: Custom meta tags
 
 The x-metaTags extension allows to add `meta` tags to the `head` of a documentation page.
 
-`x-metaTags` can be added at different levels: root, topic, tag ([when grouping by tag](/help/customization-options/operations-navigation/#group-operations-by-tag)), operation, webhook, ...
+`x-metaTags` can be added at different levels: root, topic, tag ([when grouping by tag](/help/customization-options/operations-navigation/#group-operations-by-tag)), operation, webhook, message, ...
 
 Tags added to the root of the API definition file will be added to every page of the documentation. Tags added at any other level will only be added to the corresponding pages.
 

--- a/src/_help/specification-support/meta-tags.md
+++ b/src/_help/specification-support/meta-tags.md
@@ -5,7 +5,7 @@ title: Custom meta tags
 - TOC
 {:toc}
 
-The x-metaTags extension allows to add `meta` tags to the `head` of a documentation page.
+The x-metaTags extension allows to add `meta` tags to the `head` of a documentation page. For example, to enhance your own global search with more precise filtering through facets, thanks to custom meta tags retrieved by your internal crawler.
 
 `x-metaTags` can be added at different levels: root, topic, tag ([when grouping by tag](/help/customization-options/operations-navigation/#group-operations-by-tag)), operation, webhook, message, ...
 

--- a/src/_help/specification-support/meta-tags.md
+++ b/src/_help/specification-support/meta-tags.md
@@ -47,6 +47,5 @@ paths:
   <meta name="First root tag" content="First root tag content" />
   <meta name="Second root tag" content="Second root tag content" />
   <meta name="Operation tag" content="Operation tag content" />
-
 </head>
 ```


### PR DESCRIPTION
Hey,

Here's a small PR to help users use the freshly released `x-metaTags`
- I added the page to "Common Elements" as I didn't see it fit in any other part of the global flow. Tell me if you think otherwise 🙏
- I would love to:
  - know if it's understandable as explained now, with the multiple examples,
  - get a validation of these examples reliability.
- I took the opportunity to sort the pages under "Common Elements" alphabetically in the sidebar. Is it a best practice, and if so, should we do it for every section of the sidebar? (In "Public documentation" for example").

Thanks a lot 💙