### PR TITLE
Add filename structure info to GHA help page

### DIFF
--- a/src/_help/continuous-integration/github-actions.md
+++ b/src/_help/continuous-integration/github-actions.md
@@ -220,9 +220,9 @@ jobs:
 
 Please note, by default, only files named `{slug}-api.[format]` are deployed. Where `{slug}` is a name for your API and `[format]` is either `yaml` or `json`. Adjust to your file naming convention using the `filename_pattern:` input.
 
-Note that it _can_ include `*` wildcard special character, but **must** include the `{slug}` filter to extract your documentation’s slug from the filename. The pattern can also have any other optional fixed characters.
+The pattern _can_ include `*` wildcard special character, but **must** include the `{slug}` filter to extract your documentation’s slug from the filename. The pattern can also have any other optional fixed characters.
 
-Here’s a practical example. Let's assume that you have the following files in your `path/to/apis/` directory:
+Here’s a practical example. Let’s assume that you have the following files in your `path/to/apis/` directory:
 
 ```
 path/to/apis
@@ -233,7 +233,7 @@ path/to/apis
 └─ README.md
 ```
 
-In order to deploy the 3 services API definition files from this folder (`private-api-users-service.json`, `partner-api-payments-service.yml` and `public-api-contracts-service.yml`), you can set call the action like this:
+In order to deploy the 3 services API definition files from this folder (`private-api-users-service.json`, `partner-api-payments-service.yml` and `public-api-contracts-service.yml`), you can use the action like this:
 
 ```
 [...]


### PR DESCRIPTION
Quick update of the GitHub Action page to reflect the information about our filename system from the CLI page.