### PR TITLE
Add pricing information for some features

### DIFF
--- a/src/_help/customization-options/index.md
+++ b/src/_help/customization-options/index.md
@@ -10,3 +10,6 @@ Bump.sh offers several customization options for your documentation and hubs to 
 [Custom Domains](/help/customization-options/custom-domains/) allow you to replace Bump.sh's domain in URLs with your own, making it easier to access your documentation. You can also customize the color, [logo and social media image](/help/customization-options/color-logo-meta-images/) to maintain your brand's visibility.
 
 Finally, you can define the method for [sorting API operations](/help/customization-options/operations-navigation/) to offer a comfortable and smooth reading experience.
+
+> Some customization options, such as [Embed mode](/help/customization-options/embed-mode/), depend on the plan you have subscribed to. Feel free to [contact us](mailto:hello@bump.sh) if you’d like to take advantage of a specific feature.
+{: .info}

--- a/src/_help/hubs/create-and-manage-hubs.md
+++ b/src/_help/hubs/create-and-manage-hubs.md
@@ -19,6 +19,9 @@ Finally, you can decide whether this hub is visible to everyone or only to membe
 
 ![](/images/help/hub-creation.png)
 
+> Hubs are a feature available in our [paid plans](https://bump.sh/pricing/).
+{: .info}
+
 ## Add documentation to a hub
 
 ### Using the webapp

--- a/src/_help/hubs/index.md
+++ b/src/_help/hubs/index.md
@@ -13,7 +13,7 @@ With hubs, your API ecosystem is displayed on a single page, where documentation
 
 Hubs also provide a unified changelog, making it easy to identify all changes across all the documentation it contains at a glance. Search is also global, allowing you to search across all documentation.
 
-> Hubs are available from our paid plans.
+> Hubs are a feature available in our [paid plans](https://bump.sh/pricing/).
 {: .info}
 
 Next step: [Create your first hub](/help/hubs/create-and-manage-hubs/)

--- a/src/_help/organizations/organization-access-management.md
+++ b/src/_help/organizations/organization-access-management.md
@@ -5,6 +5,9 @@ title: Organization Access Management
 - TOC
 {:toc}
 
+> The Access Management features available depend on the [subscribed plan](https://bump.sh/pricing/).
+{: .info}
+
 ## Roles
 
 The roles allow you to precisely choose which permissions to assign to members of your organization. The details of permissions by role are available below:
@@ -35,7 +38,7 @@ This page can be customized with a logo and specific button labels and descripti
 
 The login page will systematically appear when attempting to access via the direct URL of a documentation or a hub behind this SSO, if one is not already authenticated.
 
-> SSO is a feature available from our Business plan.
+> SSO is a feature available from our Enterprise plan.
 {: .info}
 
 ### How to setup SSO

--- a/src/_help/publish-documentation/branching.md
+++ b/src/_help/publish-documentation/branching.md
@@ -17,6 +17,9 @@ Switching from one API definition to another in the documentation can be done in
 
 ![](/images/help/version-selector.png)
 
+> Branches are available in our [paid plans](https://bump.sh/pricing/).
+{: .info}
+
 ## Create a branch
 
 From the documentation settings, the Branches section allows you to create branches. Enter the name of the new branch and confirm. You can also create branches directly with our CLI or our API.

--- a/src/_help/publish-documentation/deploy-and-release-management.md
+++ b/src/_help/publish-documentation/deploy-and-release-management.md
@@ -49,6 +49,9 @@ The Deployments section of your documentation provides access to the history of 
 
 ### Manual Release
 
+> Manual Release is available starting from our [Enterprise plan](https://bump.sh/pricing/).
+{: .info}
+
 The Manual Release mode is an option that allows you to separate the processing step from the releasing step of your API definition.
 
 ![](/images/help/manual-release-toggle.png)
@@ -68,6 +71,9 @@ The release preparation page will appear, allowing you to add context by adding 
 ![](/images/help/deployment-release-form.png)
 
 ### Unrelease an API definition
+
+> Unrelease a version is available in our [paid plans](https://bump.sh/pricing/).
+{: .info}
 
 It is possible to "unrelease" any previously released deployment. By clicking on the deployment, you will find the "Unrelease" option under the "..." button.
 

--- a/src/_help/publish-documentation/documentation-access-management.md
+++ b/src/_help/publish-documentation/documentation-access-management.md
@@ -17,6 +17,9 @@ They require user authentication to be accessible and are not indexed by search 
 
 ![](/images/help/documentation-access-choice.png)
 
+> The Access Management features available depend on the [subscribed plan](https://bump.sh/pricing/).
+{: .info}
+
 ## Private
 
 ### Members of an organization


### PR DESCRIPTION
In the Help Center, some features restricted to certain plans didn’t display that information. It has now been added where relevant to clarify which plan is required to access them.