### PR TITLE
Adapt sidebar component to support version select

### DIFF
--- a/src/_components/shared/sidebar.css
+++ b/src/_components/shared/sidebar.css
@@ -6,13 +6,13 @@ side-bar {
 
   aside {
     padding: var(--spacing-14) var(--spacing-4);
-  
+
     > button {
       display: none;
     }
   }
 
-  :is(h1) {
+  :is(h2) {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;

--- a/src/_components/shared/sidebar.erb
+++ b/src/_components/shared/sidebar.erb
@@ -4,6 +4,7 @@
       <svg width="11" height="12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m10 6 .543.517a.75.75 0 0 0 0-1.034L10 6ZM0 6.75h10v-1.5H0v1.5Zm10.543-1.267-4.762-5-1.086 1.034 4.762 5 1.086-1.034Zm-1.086 0-4.762 5 1.086 1.034 4.762-5-1.086-1.034Z" fill="#025FD7"/></svg>
       Hide menu
     </button>
+    <%= slotted :before %>
     <ul class="sidebar-list" data-controller="sidebar">
       <% @data.each do |page| %>
         <li>

--- a/src/_guides/openapi/specification/v3.1/_defaults.yml
+++ b/src/_guides/openapi/specification/v3.1/_defaults.yml
@@ -1,2 +1,6 @@
 sidebar_version: "v3.1"
+sidebar_versions:
+  - "v3.1"
+  - "v3.2"
 sidebar_name: openapi_v3-1
+sidebar_title: OpenAPI Specification

--- a/src/_layouts/documentation.erb
+++ b/src/_layouts/documentation.erb
@@ -6,10 +6,19 @@ layout: application
 <%= render Shared::Sidebar.new(data: @entries, current: resource) do |sidebar| %>
   <% if resource.data.sidebar_title.present? %>
     <% sidebar.slot :before do %>
-      <h1>
+      <h2>
         <%= resource.data.sidebar_title %>
-        <span class="version"><%= resource.data.sidebar_version %></span>
-      </h1>
+        <%# TODO: move in dedicated component %>
+        <% if resource.data.sidebar_versions.any? %>
+          <select class="version" name="version">
+            <% resource.data.sidebar_versions.each do |selectable_sidebar_version| %>
+              <option value=<%= selectable_sidebar_version %> <%= "selected" if selectable_sidebar_version == resource.data.sidebar_version%>><%= selectable_sidebar_version %></option>
+            <% end %>
+          </select>
+        <% else %>
+          <span class="version"><%= resource.data.sidebar_version %></span>
+        <% end %>
+      </h2>
     <% end %>
   <% end %>
   <% if resource.data.display_cta.present? %>


### PR DESCRIPTION
**Preliminary work:**

- Display slot 'before' if provides, with `<%= slotted :before %>`
- Favor tag h2 for this slot, to have only one h1 per page

**Version selector**

Be generic, provide a list of selectable version in `data.sidebar_versions` When sidebar_versions are provided, display a (raw) select HTML.

TODO:
- improve CSS for this select (dedicated component)
- improve behavior: add link between v3.1 & v3.2 support smart SEO logic when page is missing