### PR TITLE
SEO: fix canonical_url duplication

### DIFF
--- a/src/_partials/_head.erb
+++ b/src/_partials/_head.erb
@@ -5,8 +5,5 @@
 <link rel="shortcut icon" type="image/svg+xml" href="<%= relative_url site.config["metadata"]["favicon_dark"] %>" media="(prefers-color-scheme: dark)">
 <link rel="preload" href="/website<%= asset_path "fonts/saans-uprights-variable-subset.woff2" %>" as="font" type="font/woff2" crossorigin fetchpriority="high">
 <link rel="stylesheet" href="<%= webpack_path :css %>" />
-<% if data.canonical_url.present? %>
-  <link rel="canonical" href="<%= data.canonical_url %>" />
-<% end %>
 <script src="<%= webpack_path :js %>" defer></script>
 <%= live_reload_dev_js %>


### PR DESCRIPTION
When `data.canonical_url`, I noticed that
HTML tag `<link rel="canonical" href="<%= data.canonical_url %>" />` is rendered twice.

canonical URL is already included in logic `<%= seo %>`, thanks to gem `bridgetown-seo-tag`
cf doc https://www.rubydoc.info/gems/bridgetown-seo-tag/6.0.0

for example https://docs.bump.sh/guides/api-basics/api-architecture-diagrams/

<img width="517" height="65" alt="image" src="https://github.com/user-attachments/assets/341923da-ed83-461c-ac08-c2e4dbc11e6a" />
