### PR TITLE
Sidebar: Improve vertical spacing

### DIFF
--- a/src/_components/shared/sidebar.css
+++ b/src/_components/shared/sidebar.css
@@ -18,6 +18,7 @@ side-bar {
     justify-content: space-between;
     align-items: baseline;
     font-size: var(--text-xl);
+    margin-block-start: 0;
     margin-block-end: var(--spacing-4);
 
     span {


### PR DESCRIPTION
Since #405, slot 'before' is visible, with h2 tag. But margin-top has to be removed to maintain same vertical spacing.

|before|after|
|--|--|
|<img width="304" height="394" alt="image" src="https://github.com/user-attachments/assets/6b85eba8-daa6-421e-8525-932a7dc767b7" /> | <img width="304" height="394" alt="image" src="https://github.com/user-attachments/assets/8687500c-d3ca-44a6-8efc-8933aa34036a" /> | 


[Visible here](https://deploy-preview-411--bump-content-hub.netlify.app/guides/openapi/specification/v3.1/introduction/what-is-openapi/)
