### PR TITLE
help center: Add Arazzo specification page

### DIFF
--- a/src/_data/sidebars/help.yml
+++ b/src/_data/sidebars/help.yml
@@ -171,6 +171,8 @@ resources:
         items:
           - label: Flower support
             link: /mcp-servers/specification-support/flower-support/
+          - label: Arazzo support
+            link: /mcp-servers/specification-support/arazzo-support/
   - type: category
     label: Organizations
     link: /organizations/

--- a/src/_help/mcp-servers/index.md
+++ b/src/_help/mcp-servers/index.md
@@ -26,7 +26,7 @@ This architecture keeps credentials and sensitive API responses away from the LL
 Workflows can be written in two formats:
 
 - [**Flower**](/help/mcp-servers/specification-support/flower-support): a lightweight specification designed by Bump.sh. Ideal for small projects, quick prototyping, or workflows calling APIs for which you don't have an OpenAPI document.
-- **Arazzo**: the workflow specification from the OpenAPI Initiative. Better suited for complex projects that need to reference existing OpenAPI documents.
+- [**Arazzo**](/help/mcp-servers/specification-support/arazzo-support): the workflow specification from the OpenAPI Initiative. Better suited for complex projects that need to reference existing OpenAPI documents.
 
 Both formats support multi-step sequences, conditional logic (retry, goto, end), runtime expressions, and secrets.
 

--- a/src/_help/mcp-servers/specification-support/arazzo-support.md
+++ b/src/_help/mcp-servers/specification-support/arazzo-support.md
@@ -1,0 +1,14 @@
+---
+title: Arazzo support
+---
+
+- TOC
+{:toc}
+
+Arazzo is the workflow specification from the OpenAPI Initiative. It provides a standardized, machine-readable format for describing sequences of API calls, with support for passing data between steps, conditional branching, success criteria, and failure handling. 
+
+If you need help writing efficient Arazzo workflows, discover our [Arazzo complete guide](/arazzo/v1.0/).
+
+## When to use Arazzo
+
+We recommend using it when you already have OpenAPI documents describing your APIs, and if you want a vendor-neutral, standardized format usable by other tools. For simpler projects or APIs without OpenAPI documents, consider [Flower](/help/mcp-servers/specification-support/flower-support), our lightweight alternative.


### PR DESCRIPTION
This is a small PR to add an Arazzo page next to the "Flower specification" page.

I kept it real simple, with just a bit of context and a link to the complete guide.