### PR TITLE
Use Config- prefixed header in example

### DIFF
--- a/src/_help/mcp-servers/runtime-expressions.md
+++ b/src/_help/mcp-servers/runtime-expressions.md
@@ -132,10 +132,10 @@ Reference values tied to the user currently invoking the MCP server. Only availa
 ```yaml
 headers:
   Authorization: "Bearer $current_user.token"
-  X-Org-Id: "$current_user.org_id"
+  Config-Org-Id: "$current_user.org_id"
 ```
 
-For `$current_user.<name>`, matching is case-insensitive, and underscores in the expression map to dashes in the header. All of `$current_user.api_key`, `$current_user.API_KEY` and `$current_user.Api-Key` resolve the same `Config-Api-Key` header.
+For `$current_user.<name>`, matching is case-insensitive, and underscores in the expression map to dashes in the header. All of `$current_user.org_id`, `$current_user.ORG_ID` and `$current_user.Org-Id` resolve the same `Config-Org-Id` header.
 
 If no matching header is sent by the client, the expression resolves to an empty string.
 


### PR DESCRIPTION
As a follow-up to #457, let's use a correct header name. I also kept the current header name example `Org-Id` (instead of introducing a new `Api-Key` header which is not shown in the code example above.