### PR TITLE
Redirection developers.bump.sh

### DIFF
--- a/src/_data/footer.yml
+++ b/src/_data/footer.yml
@@ -32,7 +32,7 @@ columns:
       link: https://github.com/bump-sh/cli
     - label: Status
       link: https://status.bump.sh/
-    - label: API Reference
+    - label: API References
       link: https://developers.bump.sh/
     - label: Contact
       link: mailto:hello@bump.sh

--- a/src/_data/home.yml
+++ b/src/_data/home.yml
@@ -7,12 +7,11 @@ cards:
     description: Learn about APIs at large, and how to use Bump.sh in your API ecosystem
     link: /guides/
     icon: icons/guides
-  - label: API Reference
-    description: Find the documentation to our very own API
+  - label: API References
+    description: Find documentation of our own APIs
     link: https://developers.bump.sh/
     icon: icons/api-reference
   - label: Product Updates
     description: Learn about our latest features and changes
     link: /product-updates/
     icon: icons/product-updates
-    

--- a/src/_data/navbar.yml
+++ b/src/_data/navbar.yml
@@ -5,5 +5,5 @@ left_links:
   - {title: "OpenAPI specification", link: "/openapi/v3.2/"}
   - {title: "Arazzo specification", link: "/arazzo/v1.0/"}
 right_links:
-  - {title: "API reference", link: "https://developers.bump.sh"}
+  - {title: "API references", link: "https://developers.bump.sh/"}
   - {title: "Bump.sh", link: "https://bump.sh"}

--- a/src/_guides/bump-sh-tutorials/make-your-apis-discoverable-with-apisjson.md
+++ b/src/_guides/bump-sh-tutorials/make-your-apis-discoverable-with-apisjson.md
@@ -118,7 +118,7 @@ If you want to automate submissions and updates then you can use the [APIs.io AP
 
 ### Private Bump.sh Hubs
 
-If you want to make your hubs private but still want to access the data in APIs.json, then you can access it via the [Bump.sh API](https://developers.bump.sh/) using the [Hubs endpoint](https://developers.bump.sh/operation/operation-get-hubs-parameter).
+If you want to make your hubs private but still want to access the data in APIs.json, then you can access it via the [Bump.sh API](https://developers.bump.sh/doc/workspace/) using the [Hubs endpoint](https://developers.bump.sh/doc/workspace/operation/operation-get-hubs-parameter).
 
 ```
 curl -X GET https://bump.sh/api/v1/hubs/<hub-slug-or-id> -H "Authorization: Token <access-token>"

--- a/src/_help/api-change-management/index.md
+++ b/src/_help/api-change-management/index.md
@@ -11,7 +11,7 @@ Bump automatically builds a changelog for your API. Each time you upload a new v
 
 ![The changelog link](/docs/images/help/changelog-link-dark.png)
 
-As you can see below on the [Bump API changelog](https://developers.bump.sh/changes), every changes we made are listed: whether it's a structural change (endpoint or parameter removed, modified or added for example) or a content change (description or example modification).
+As you can see below on the [Bump API changelog](https://developers.bump.sh/doc/workspace/changes), every changes we made are listed: whether it's a structural change (endpoint or parameter removed, modified or added for example) or a content change (description or example modification).
 
 ![Bump API changelog](/docs/images/help/changelog.png)
 
@@ -43,7 +43,7 @@ Users can subscribe to your API changelog and receive a weekly digest.
 
 ### RSS
 
-The changelog page exposes an RSS feed your users can subscribe to. Here is an example with the [Bump API changelog](https://developers.bump.sh/changes.rss).
+The changelog page exposes an RSS feed your users can subscribe to. Here is an example with the [Bump API changelog](https://developers.bump.sh/doc/workspace/changes.rss).
 
 ### Webhooks
 

--- a/src/_help/api-change-management/webhooks.md
+++ b/src/_help/api-change-management/webhooks.md
@@ -42,11 +42,10 @@ The **Recent deliveries** section include a **Test Webhook **element that helps 
 
 ### Payload content
 
-Details about the payload content sent for each setup webhooks is available in our [absolutely gorgeous API documentation](https://developers.bump.sh/#webhook-documentation-change).
+Details about the payload content sent for each setup webhooks is available in our [absolutely gorgeous API documentation](https://developers.bump.sh/doc/workspace/operation/operation-webhookdocstructurechange).
 
 ## Delete a webhook
 
 To stop receiving notifications, you can delete a webhook by selecting it from the **Integrations** section and then confirm the deletion in the **Danger zone**.
 
 ![](/docs/images/help/legacy/zv44dbSnFqeaZqgfIvSD.png)
-

--- a/src/_help/changes-management/integrations.md
+++ b/src/_help/changes-management/integrations.md
@@ -50,7 +50,7 @@ Finally, you can check from this same page if your setup is working correctly by
 
 ### Payload content
 
-Details about the payload content sent for each setup webhooks is available in our [Bump.sh API documentation](https://developers.bump.sh/#webhook-documentation-change).
+Details about the payload content sent for each setup webhooks is available in our [Bump.sh API documentation](https://developers.bump.sh/doc/workspace/operation/operation-webhookdocstructurechange).
 
 ### Delete a webhook
 

--- a/src/_help/continuous-integration/api.md
+++ b/src/_help/continuous-integration/api.md
@@ -5,11 +5,11 @@ title: API
 - TOC
 {:toc}
 
-If neither the [Github-Action](/help/continuous-integration/github-actions/) or the [CLI](/help/continuous-integration/cli/) are sufficient for you, please read this page to discover what you can do with the [Bump.sh API](https://developers.bump.sh).
+If neither the [Github-Action](/help/continuous-integration/github-actions/) or the [CLI](/help/continuous-integration/cli/) are sufficient for you, please read this page to discover what you can do with the [Bump.sh Workspace API](https://developers.bump.sh/doc/workspace/).
 
 ## Deploy to your documentation
 
-You can use the [`POST /versions`](https://developers.bump.sh/operation/operation-post-versions) endpoint to publish a new API document to your documentation.
+You can use the [`POST /versions`](https://developers.bump.sh/doc/workspace/operation/operation-post-versions) endpoint to publish a new API document to your documentation.
 
 You will need to provide at least the following request body parameters:
 - a `documentation` slug of your target Bump.sh documentation
@@ -21,7 +21,7 @@ The endpoint gives you some other optional parameters such as:
 
 ## Diff between two API documents
 
-You can use the [`POST /diffs`](https://developers.bump.sh/operation/operation-post-diffs) endpoint to compare two given API documents. To see the diff result you will then need to call the [`GET /diffs/:id`](https://developers.bump.sh/operation/operation-get-diffs-parameter) endpoint with the `id` returned by the POST request.
+You can use the [`POST /diffs`](https://developers.bump.sh/doc/workspace/operation/operation-post-diffs) endpoint to compare two given API documents. To see the diff result you will then need to call the [`GET /diffs/:id`](https://developers.bump.sh/doc/workspace/operation/operation-get-diffs-parameter) endpoint with the `id` returned by the POST request.
 
 For file comparison, you will need to provide at least the following request body parameters:
 - a `previous_definition` content
@@ -37,23 +37,21 @@ The endpoint gives you some other optional parameters such as:
 
 ## Manage your branches
 
-Thanks to the [Branches endpoints](https://developers.bump.sh/group/endpoint-branches) you can:
+Thanks to the [Branches endpoints](https://developers.bump.sh/doc/workspace/group/endpoint-branches) you can:
 
-- [List existing branches](https://developers.bump.sh/operation/operation-get-docs-parameter-branches) of your documentation
-- [Create a new branch](https://developers.bump.sh/operation/operation-post-docs-parameter-branches)
-- [Delete a branch](https://developers.bump.sh/operation/operation-delete-docs-parameter-branches-parameter)
-- [Promote a branch as the “default” one](https://developers.bump.sh/operation/operation-patch-docs-parameter-branches-parameter-set_default). **Warning**: this will affect your published documentation and make the given branch the default one visible by your users.
+- [List existing branches](https://developers.bump.sh/doc/workspace/operation/operation-get-docs-parameter-branches) of your documentation
+- [Create a new branch](https://developers.bump.sh/doc/workspace/operation/operation-post-docs-parameter-branches)
+- [Delete a branch](https://developers.bump.sh/doc/workspace/operation/operation-delete-docs-parameter-branches-parameter)
+- [Promote a branch as the “default” one](https://developers.bump.sh/doc/workspace/operation/operation-patch-docs-parameter-branches-parameter-set_default). **Warning**: this will affect your published documentation and make the given branch the default one visible by your users.
 
 ## List your Hubs
 
-Thanks to the [Hubs endpoints](https://developers.bump.sh/group/endpoint-hubs) you can:
+Thanks to the [Hubs endpoints](https://developers.bump.sh/doc/workspace/group/endpoint-hubs) you can:
 
-- [Fetch information of an existing Hub](https://developers.bump.sh/operation/operation-get-hubs-parameter) including the list of APIs it contains.
+- [Fetch information of an existing Hub](https://developers.bump.sh/doc/workspace/operation/operation-get-hubs-parameter) including the list of APIs it contains.
 
 ## Documentation Change Webhook
 
-Our API offers a [“documentation change” webhook](https://developers.bump.sh/operation/operation-webhookdocstructurechange), which can help you receive automated notifications whenever one of your documentation receives a new published API document.
+Our API offers a [“documentation change” webhook](https://developers.bump.sh/doc/workspace/operation/operation-webhookdocstructurechange), which can help you receive automated notifications whenever one of your documentation receives a new published API document.
 
 For more information on how to use this webhook please check the [dedicated help page](/help/api-change-management/webhooks/).
-
-

--- a/src/_help/continuous-integration/cli.md
+++ b/src/_help/continuous-integration/cli.md
@@ -13,7 +13,7 @@ Using [OpenAPI](https://spec.openapis.org/) (v3.x and v2.0) or [AsyncAPI](https:
 - Publish an API document to your Bump.sh documentation or hubs.
 - Compare two API documents to generate a human-readable diff from your API definition.
 
-Under the hood, it uses the API of [developers.bump.sh](https://developers.bump.sh). And is built with the [`oclif`](https://oclif.io) framework in Typescript.
+Under the hood, it uses the [Bump.sh Workspace API](https://developers.bump.sh/doc/workspace/). And is built with the [`oclif`](https://oclif.io) framework in Typescript.
 
 > You can use the CLI to interact with your MCP server:
 > see how to [deploy a workflow document on your MCP server](#deploy-a-workflow-document-on-your-mcp-server).
@@ -65,7 +65,7 @@ npx bump --help
 
 ### Can I install Bump.sh CLI without using NodeJS?
 
-Unfortunately, at the moment we only support the Node environment. However, you can download a standalone package directly from the [latest Github release](https://github.com/bump-sh/cli/releases) assets which you can run as a standalone binary. Or you can push your documentation using [our API](https://developers.bump.sh/) (advanced usage only).
+Unfortunately, at the moment we only support the Node environment. However, you can download a standalone package directly from the [latest Github release](https://github.com/bump-sh/cli/releases) assets which you can run as a standalone binary. Or you can push your documentation using [our API](https://developers.bump.sh/doc/workspace/) (advanced usage only).
 
 ## Usage
 
@@ -252,7 +252,7 @@ bump preview path/to/file.json
 You can also preview a document available via a URL:
 
 ```shell
-bump preview https://developers.bump.sh/source.yaml
+bump preview https://developers.bump.sh/doc/workspace/source.yaml
 ```
 
 #### Live preview

--- a/src/_help/documentation-experience/ask-ai-markdown-rendering.md
+++ b/src/_help/documentation-experience/ask-ai-markdown-rendering.md
@@ -15,7 +15,7 @@ Many API consumers now rely on AI tools to help them quickly discover API capabi
 ## Markdown rendering
 To access the Markdown version of a documentation, add `.md` at the end of the URL (or `/source.md` if you have a custom domain, when the URL is the root of your documentation).
 
-[On a documentation root](https://developers.bump.sh/source.md) *(example truncated for visibility purposes).*
+[On a documentation root](https://developers.bump.sh/doc/workspace/source.md) *(example truncated for visibility purposes).*
 ```markdown
 # Bump.sh Api
 
@@ -31,16 +31,16 @@ The Bump.sh API is a REST API. It enables you to [...]
 
 
 ## Endpoints
-- [Branches](https://developers.bump.sh/group/endpoint-branches.md)
-- [Diffs](https://developers.bump.sh/group/endpoint-diffs.md)
+- [Branches](https://developers.bump.sh/doc/workspace/group/endpoint-branches.md)
+- [Diffs](https://developers.bump.sh/doc/workspace/group/endpoint-diffs.md)
 - [...]
 
 
 ## Webhooks
-- [Documentation change](https://developers.bump.sh/group/webhook-documentation-change.md)
+- [Documentation change](https://developers.bump.sh/doc/workspace/group/webhook-documentation-change.md)
 ````
 
-[For a specific operation](https://developers.bump.sh/operation/operation-post-versions.md) *(example truncated for visibility purposes).*
+[For a specific operation](https://developers.bump.sh/doc/workspace/operation/operation-post-versions.md) *(example truncated for visibility purposes).*
 ```markdown
 # Create a new version
 

--- a/src/_help/hubs/create-and-manage-hubs.md
+++ b/src/_help/hubs/create-and-manage-hubs.md
@@ -59,7 +59,7 @@ However, the API does not currently support the following actions:
 - Modifying the metadata of a hub (title, description, settings, etc.).
 - Deleting a hub.
 
-[For more information, please refer to our API documentation.](https://developers.bump.sh/)
+[For more information, please refer to our API documentation.](https://developers.bump.sh/doc/workspace/)
 
 ## Hub access management
 

--- a/src/_help/publish-documentation/branching.md
+++ b/src/_help/publish-documentation/branching.md
@@ -66,9 +66,9 @@ bump deploy path/to/file.json --doc my-documentation --branch staging
 
 ### Using the API
 
-Our [API](https://developers.bump.sh/operation/operation-post-versions) lets you publish to a specific branch by providing the `branch_name` request body parameter. However, we recommend using either our CLI or our Github-Action to publish your API documents to Bump.sh.
+Our [API](https://developers.bump.sh/doc/workspace/operation/operation-post-versions) lets you publish to a specific branch by providing the `branch_name` request body parameter. However, we recommend using either our CLI or our Github-Action to publish your API documents to Bump.sh.
 
-Our dedicated [Branch API](https://developers.bump.sh/group/endpoint-branches) endpoints, help to manage the branches of your documentation. You can create a new branch, delete one, list them all, or select one as the default branch.
+Our dedicated [Branch API](https://developers.bump.sh/doc/workspace/group/endpoint-branches) endpoints, help to manage the branches of your documentation. You can create a new branch, delete one, list them all, or select one as the default branch.
 
 Please note that, currently, the API does not support renaming a branch.
 

--- a/src/_product-updates/2020-11-12-add-a-favicon-to-your-documentation.md
+++ b/src/_product-updates/2020-11-12-add-a-favicon-to-your-documentation.md
@@ -7,7 +7,7 @@ Until now, for documentation having a customised logo, the same one was used as 
 
 From now on, you can use a specific one, to brighten up your documentation more than ever!
 
-Here is how [Bump's documentation](https://developers.bump.sh/) looks like now:
+Here is how [Bump's documentation](https://developers.bump.sh/doc/workspace/) looks like now:
 
 ![Bump doc with favicon.png](/docs/images/changelog/favicon.png)
 

--- a/src/_product-updates/2021-07-13-download-source-from-your-documentation.md
+++ b/src/_product-updates/2021-07-13-download-source-from-your-documentation.md
@@ -5,6 +5,6 @@ tags: [New]
 
 ![download-source.png](/docs/images/changelog/download-source.png)
 
-We've made it easy for API consumers to [download the source](https://developers.bump.sh/) of an API documentation.
+We've made it easy for API consumers to [download the source](https://developers.bump.sh/doc/workspace/) of an API documentation.
 
 Whether you want to get your hands on a `JSON` or `YAML` format, for `OpenAPI` or `AsyncAPI`, you're now just a click away.

--- a/src/_product-updates/2021-07-18-receive-api-changelog-in-your-mailbox.md
+++ b/src/_product-updates/2021-07-18-receive-api-changelog-in-your-mailbox.md
@@ -9,7 +9,7 @@ In API documentation, changelogs are important, and your API consumers need to s
 
 It's now possible for them to subscribe by email to your API changelog: they will receive a summary of the changelog every week in their mailbox!
 
-Want to see it in action on Bump API documentation? [See it live](https://developers.bump.sh/changes)
+Want to see it in action on Bump API documentation? [See it live](https://developers.bump.sh/doc/workspace/changes)
 
 Do not hesitate to invite your API consumers to subscribe to your API updates (available at `http://{your-doc-url}/changes`)
 

--- a/src/_product-updates/2021-09-11-share-and-highlight-anything-inside-your-api-documentation.md
+++ b/src/_product-updates/2021-09-11-share-and-highlight-anything-inside-your-api-documentation.md
@@ -3,11 +3,11 @@ title: Share and highlight anything inside your API documentation
 tags: [New]
 ---
 
-To give your users the best API onboarding, 
-it often helps to be able to share specific pieces of information. 
+To give your users the best API onboarding,
+it often helps to be able to share specific pieces of information.
 
 Thanks to this new feature, you can now share and highlight anything in your API documentation with just a click. The selected element will be highlighted following your color theme.
 
 ![share_highlight.gif](/docs/images/changelog/share_highlight.gif)
 
-Give it a try: [https://developers.bump.sh/operation/operation-post-previews](https://developers.bump.sh/operation/operation-post-previews)
+Give it a try: [https://developers.bump.sh/doc/workspace/operation/operation-post-previews](https://developers.bump.sh/doc/workspace/operation/operation-post-previews)

--- a/src/_product-updates/2021-09-20-rss-feed-for-your-changelog.md
+++ b/src/_product-updates/2021-09-20-rss-feed-for-your-changelog.md
@@ -9,4 +9,4 @@ In the age of information overload, getting access to information that matters c
 
 From now, get notified of the API changes through RSS in addition to the existing email.
 
-Give it a try with the [Bump RSS feed](https://developers.bump.sh/changes.rss) in your favorite RSS reader.
+Give it a try with the [Bump RSS feed](https://developers.bump.sh/doc/workspace/changes.rss) in your favorite RSS reader.

--- a/src/_product-updates/2021-09-21-changelog-makeover.md
+++ b/src/_product-updates/2021-09-21-changelog-makeover.md
@@ -8,4 +8,4 @@ tags: [Improvement]
 
 We redesigned the whole changelog page in order to bring you a better understanding of changes history of your API.
 
-Here's an example: https://developers.bump.sh/changes
+Here's an example: https://developers.bump.sh/doc/workspace/changes

--- a/src/_product-updates/2021-10-03-automatic-breaking-change-detection.md
+++ b/src/_product-updates/2021-10-03-automatic-breaking-change-detection.md
@@ -5,7 +5,7 @@ tags: [New]
 
 If some changes are more important than others, it is especially true for your API.
 
-From now on, we automatically detect if a new version of your API includes some breaking changes. It will be visible in the [changelog page](https://developers.bump.sh/changes), in the changelog email or the brand new RSS feed… but also during your API design phase while opening a pull request thanks to [our Github Action](https://github.com/bump-sh/github-action/).
+From now on, we automatically detect if a new version of your API includes some breaking changes. It will be visible in the [changelog page](https://developers.bump.sh/doc/workspace/changes), in the changelog email or the brand new RSS feed… but also during your API design phase while opening a pull request thanks to [our Github Action](https://github.com/bump-sh/github-action/).
 
 
 ![breaking_changes.png](/docs/images/changelog/breaking_changes.png)

--- a/src/_product-updates/2022-01-15-changelog-update.md
+++ b/src/_product-updates/2022-01-15-changelog-update.md
@@ -5,9 +5,9 @@ tags: [Improvement]
 
 The API changelog page has been redesigned to give you a clearer view of what has changed inside your API, it is the groundwork of having fine-grained changelog details 🕵️
 
-Hope you will enjoy it! 
+Hope you will enjoy it!
 
-See it in action on our [own API documentation](https://developers.bump.sh/changes)
+See it in action on our [own API documentation](https://developers.bump.sh/doc/workspace/changes)
 
 • Bonus point:
 

--- a/src/_product-updates/2023-06-16-api-branch-management.md
+++ b/src/_product-updates/2023-06-16-api-branch-management.md
@@ -6,11 +6,11 @@ image: /docs/images/changelog/bump-sh-api-branch-management.png
 
 ![bump-sh-api-branch-management.png](/docs/images/changelog/bump-sh-api-branch-management.png)
 
-Branch Management is now available from the [Bump.sh API](https://developers.bump.sh/), making your API evolution workflows a whole lot smoother as an easy and effective way to manage your versions and optimizes how you deliver ephemeral or major ones, at hand (at least within our API).
+Branch Management is now available from the [Bump.sh API](https://developers.bump.sh/doc/workspace/), making your API evolution workflows a whole lot smoother as an easy and effective way to manage your versions and optimizes how you deliver ephemeral or major ones, at hand (at least within our API).
 
 ### Let's explore how these new features simplify your API workflow
 
-1. [Branch creation](https://developers.bump.sh/operation/operation-post-docs-parameter-branches): Create a new branch effortlessly with a single API call, eliminating manual work.
-2. [List of Branches](https://developers.bump.sh/operation/operation-get-docs-parameter-branches): Obtain an overview of all API branches, facilitating efficient management and organization.
-3. [Set Default Branch](https://developers.bump.sh/operation/operation-patch-docs-parameter-branches-parameter-set_default): Easily choose and showcase a default branch for up-to-date API documentation.
-4. [Delete Branch](https://developers.bump.sh/operation/operation-delete-docs-parameter-branches-parameter): Remove unnecessary branches to maintain a clean and organized development environment.
+1. [Branch creation](https://developers.bump.sh/doc/workspace/operation/operation-post-docs-parameter-branches): Create a new branch effortlessly with a single API call, eliminating manual work.
+2. [List of Branches](https://developers.bump.sh/doc/workspace/operation/operation-get-docs-parameter-branches): Obtain an overview of all API branches, facilitating efficient management and organization.
+3. [Set Default Branch](https://developers.bump.sh/doc/workspace/operation/operation-patch-docs-parameter-branches-parameter-set_default): Easily choose and showcase a default branch for up-to-date API documentation.
+4. [Delete Branch](https://developers.bump.sh/doc/workspace/operation/operation-delete-docs-parameter-branches-parameter): Remove unnecessary branches to maintain a clean and organized development environment.

--- a/src/_product-updates/2023-08-09-changelog-layout.md
+++ b/src/_product-updates/2023-08-09-changelog-layout.md
@@ -9,4 +9,4 @@ image: /docs/images/changelog/changelog-layout.png
 The changelog is a crucial part of your API ecosystem, providing a clear view of what's new, changed, fixed or removed.
 We've redesigned it to make it cleaner, clearer and more efficient while maintaining the ability for anyone to stay aware of updates, one click away.
 
-Check how it looks on the Bump.sh API doc: [it is absolutely stunning](https://developers.bump.sh/changes).
+Check how it looks on the Bump.sh API doc: [it is absolutely stunning](https://developers.bump.sh/doc/workspace/changes).

--- a/src/_product-updates/2023-08-30-change-comparison.md
+++ b/src/_product-updates/2023-08-30-change-comparison.md
@@ -10,7 +10,7 @@ APIs evolve constantly, each iteration creating changes, breaking ones or not. A
 
 We have worked on a new feature that allows to compare any versions of an API with another, accessible from its changelog. Changes are instantly highlighted, and if you need to easily share the result with your teammates, we got you covered: use the generated link or even better, try to press `Y` key!
 
-Come and test this new feature directly on [Bump.sh API documentation](https://developers.bump.sh/compare).
+Come and test this new feature directly on [Bump.sh API documentation](https://developers.bump.sh/doc/workspace/compare).
 
 **Improvements and fixes**
 

--- a/src/_product-updates/2023-11-02-changelog-diff.md
+++ b/src/_product-updates/2023-11-02-changelog-diff.md
@@ -12,4 +12,4 @@ With the new Changelog Diff, you get a clearer overview of EVERY change. Instead
 
 We've also overhauled the visual aspect of a diff. The hierarchy of information is clearer and more intuitive, as is the order of change statuses, which is now better ordered.
 
-Now available to see on your API, or [see it in action on Bump.sh API Changelog →](https://developers.bump.sh/changes)
+Now available to see on your API, or [see it in action on Bump.sh API Changelog →](https://developers.bump.sh/doc/workspace/changes)

--- a/src/_product-updates/2024-06-10-changelog-entry-page.md
+++ b/src/_product-updates/2024-06-10-changelog-entry-page.md
@@ -10,6 +10,6 @@ We have recently improved the changelog to make it easier to share updates to yo
 
 In addition to the continuous deployment flow of the changelog, you can now click on each entry to view an individual page for a specific change. This option allows you to easily share a link directly pointing to the changes you don't want your API consumers to miss, whether they are members of your organization or partners.
 
-Our API documentation allows you to easily test the rendering of these new pages, as shown with [this example](https://developers.bump.sh/changes/2bedfeb6).
+Our API documentation allows you to easily test the rendering of these new pages, as shown with [this example](https://developers.bump.sh/doc/workspace/changes/2bedfeb6).
 
 We have many more updates coming to the changelog this year, and we can't wait to show them to you.

--- a/src/_product-updates/2025-04-10-love-cycle-april-25.md
+++ b/src/_product-updates/2025-04-10-love-cycle-april-25.md
@@ -7,9 +7,9 @@ Every now and then between larger product cycles, the whole team gets together t
 Here's a list of what's been worked on.
 
 Improvements:
-- You can now easily list all your organization's hubs using the new ``GET /hubs`` [endpoint in our API](https://developers.bump.sh/operation/operation-listhubs),
+- You can now easily list all your organization's hubs using the new ``GET /hubs`` [endpoint in our API](https://developers.bump.sh/doc/workspace/operation/operation-listhubs),
 - Our [GitHub Action](https://github.com/marketplace/actions/bump-sh-api-documentation-changelog) has been updated and now supports overlays,
-- [Bump.sh CLI](https://github.com/bump-sh/cli): 
+- [Bump.sh CLI](https://github.com/bump-sh/cli):
   - A message is now displayed at every document update, so you know the CLI is running and updating the preview properly,
   - When using `bump overlay`, we now display a message if an overlay doesn't match anything,
   - When using `bump deploy`, an explicit message is displayed if the target directory doesn't exist.

--- a/src/_product-updates/2025-12-22-openapi-3-2-partial-support.md
+++ b/src/_product-updates/2025-12-22-openapi-3-2-partial-support.md
@@ -6,17 +6,17 @@ image: /docs/images/changelog/openapi-3-2-partial-support.png
 
 ![openapi-3-2-partial-support.png](/docs/images/changelog/openapi-3-2-partial-support.png)
 
-The OpenAPI Initiative released a new version of their OpenAPI specification in September: [OpenAPI 3.2](https://spec.openapis.org/oas/v3.2.0.html). 
+The OpenAPI Initiative released a new version of their OpenAPI specification in September: [OpenAPI 3.2](https://spec.openapis.org/oas/v3.2.0.html).
 
-If you didn't hear about this new version, feel free to read our [OpenAPI complete guide](/openapi/v3.2/), updated for OpenAPI 3.2. 
+If you didn't hear about this new version, feel free to read our [OpenAPI complete guide](/openapi/v3.2/), updated for OpenAPI 3.2.
 
 We started supporting some of the features brought by this new version:
 - The QUERY method is now supported in both the documentation and the API Explorer.
 - Servers can now have a `name`, which can be combined with the existing `description` field to provide users with a clear context about a server's usage.
 - Tags now offers a `summary` property. Behaving like our existing x-displayName vendor extension, it gives a way to display a group name in the documentation that is different from the tag name.
 - `summary` can be added to responses when the level of detail doesn't justify the use of the existing `description` field.
-- Security schemes can now be `deprecated`. 
+- Security schemes can now be `deprecated`.
 
-OpenAPI 3.2 definition files can be deployed through your usual deployment process: using our [Github Action](https://github.com/bump-sh/github-action), our [CLI](https://github.com/bump-sh/cli), our [API](https://developers.bump.sh/) (now in OpenAPI 3.2 ✨), or directly in your Bump.sh dashboard.
+OpenAPI 3.2 definition files can be deployed through your usual deployment process: using our [Github Action](https://github.com/bump-sh/github-action), our [CLI](https://github.com/bump-sh/cli), our [API](https://developers.bump.sh/doc/workspace/) (now in OpenAPI 3.2 ✨), or directly in your Bump.sh dashboard.
 
 As always, you can reach out at [hello@bump.sh](mailto:hello@bump.sh) for any questions/feedback.

--- a/src/_product-updates/2025-12-8-ask-ai-markdown-rendering.md
+++ b/src/_product-updates/2025-12-8-ask-ai-markdown-rendering.md
@@ -20,7 +20,7 @@ Bump.sh now offers an alternative context optimized for AI tools through Markdow
 
 To access the Markdown version of a documentation, simply add `.md` at the end of the URL (or `/source.md` if you have a custom domain, when the URL is the root of your documentation).
 
-[On a documentation root](https://developers.bump.sh/source.md) *(example truncated for visibility purposes).*
+[On a documentation root](https://developers.bump.sh/doc/workspace/source.md) *(example truncated for visibility purposes).*
 ```markdown
 # Bump.sh Api
 
@@ -36,27 +36,27 @@ The Bump.sh API is a REST API. It enables you to [...]
 
 
 ## Topics
-- [Authentication](https://developers.bump.sh/authentication.md)
+- [Authentication](https://developers.bump.sh/doc/workspace/authentication.md)
 
 
 ## Endpoints and operations
 
-### [Branches](https://developers.bump.sh/group/endpoint-branches.md)
-- [Promote branch as the default one](https://developers.bump.sh/operation/operation-patch-docs-parameter-branches-parameter-set_default.md)
-- [Delete a branch](https://developers.bump.sh/operation/operation-delete-docs-parameter-branches-parameter.md)
-- [List available branches](https://developers.bump.sh/operation/operation-get-docs-parameter-branches.md)
-- [Create a new branch](https://developers.bump.sh/operation/operation-post-docs-parameter-branches.md)
-### [Diffs](https://developers.bump.sh/group/endpoint-diffs.md)
+### [Branches](https://developers.bump.sh/doc/workspace/group/endpoint-branches.md)
+- [Promote branch as the default one](https://developers.bump.sh/doc/workspace/operation/operation-patch-docs-parameter-branches-parameter-set_default.md)
+- [Delete a branch](https://developers.bump.sh/doc/workspace/operation/operation-delete-docs-parameter-branches-parameter.md)
+- [List available branches](https://developers.bump.sh/doc/workspace/operation/operation-get-docs-parameter-branches.md)
+- [Create a new branch](https://developers.bump.sh/doc/workspace/operation/operation-post-docs-parameter-branches.md)
+### [Diffs](https://developers.bump.sh/doc/workspace/group/endpoint-diffs.md)
 - [...]
 
 
 ## Webhooks
 
-### [Documentation change](https://developers.bump.sh/group/webhook-documentation-change.md)
-- [Structure change](https://developers.bump.sh/operation/operation-webhookdocstructurechange.md)
+### [Documentation change](https://developers.bump.sh/doc/workspace/group/webhook-documentation-change.md)
+- [Structure change](https://developers.bump.sh/doc/workspace/operation/operation-webhookdocstructurechange.md)
 ````
 
-[For a specific operation](https://developers.bump.sh/operation/operation-post-versions.md) *(example truncated for visibility purposes).*
+[For a specific operation](https://developers.bump.sh/doc/workspace/operation/operation-post-versions.md) *(example truncated for visibility purposes).*
 ```markdown
 # Create a new version
 

--- a/src/_specifications/openapi/v3.1/advanced/callbacks-webhooks.md
+++ b/src/_specifications/openapi/v3.1/advanced/callbacks-webhooks.md
@@ -150,16 +150,16 @@ The key bits to notice here are:
 - The `requestBody` is the request you're going to send.
 - The `responses` property is a map of responses you want the client to return.
 
-These then don't need to be tied to paths. In fact, you can have an OpenAPI document which has no paths. This could be because you're splitting your documents up in interesting reusable ways with these webhooks being shared across multiple APIs, or because your API is entirely asynchronous. 
+These then don't need to be tied to paths. In fact, you can have an OpenAPI document which has no paths. This could be because you're splitting your documents up in interesting reusable ways with these webhooks being shared across multiple APIs, or because your API is entirely asynchronous.
 
-## Consider AsyncAPI 
+## Consider AsyncAPI
 
-If you are using a few webhooks in an API which is largely otherwise driven by request/response, OpenAPI will be just fine for you with callbacks and webhooks helping as needed. 
+If you are using a few webhooks in an API which is largely otherwise driven by request/response, OpenAPI will be just fine for you with callbacks and webhooks helping as needed.
 
 However if you are building an API that is entirely asynchronous, you are using technologies like WebSockets, or are working with any other event-driven API protocols, you should consider using [AsyncAPI](_guides/asyncapi/what-is-asyncapi.md) for describing those parts of the architecture.
 
 ## Examples
 
-There's a full example in either [Train Travel API](https://bump.sh/blog/modern-openapi-petstore-replacement), or [Bump.sh API](https://developers.bump.sh/operation/operation-webhookdocstructurechange): every structural change on API documentation generates a new request to this webhook.
+There's a full example in either [Train Travel API](https://bump.sh/blog/modern-openapi-petstore-replacement), or [Bump.sh API](https://developers.bump.sh/doc/workspace/operation/operation-webhookdocstructurechange): every structural change on API documentation generates a new request to this webhook.
 
 You can also find more information about documenting webhooks in [this blog post](https://bump.sh/blog/documenting-your-OpenAPI-webhooks).

--- a/src/_specifications/openapi/v3.1/documentation/grouping-operations-with-tags.md
+++ b/src/_specifications/openapi/v3.1/documentation/grouping-operations-with-tags.md
@@ -86,7 +86,7 @@ Tags are a powerful tool for improving the usability of your OpenAPI document. B
 
 When specifying your tags in the root level of your API contract, you can give context to the tag using the `description` property.
 
-Let’s take [Bump.sh API documentation](https://bump.sh/demo/doc/bump). Here is how the `Diffs` tag is created and described in [Bump.sh API Contract](https://developers.bump.sh):
+Let’s take [Bump.sh API documentation](https://bump.sh/demo/doc/bump). Here is how the `Diffs` tag is created and described in [Bump.sh API Contract](https://developers.bump.sh/doc/workspace/):
 
 ```yaml
 tags:
@@ -178,7 +178,7 @@ paths:
       [...]
 ```
 
-You can [see live](https://developers.bump.sh/group/endpoint-diffs) how they are all available under the section Diffs. By clicking the name of the section in the left menu, the tagged endpoints will show up.
+You can [see live](https://developers.bump.sh/doc/workspace/group/endpoint-diffs) how they are all available under the section Diffs. By clicking the name of the section in the left menu, the tagged endpoints will show up.
 
 ![tagged endpoints on Bump.sh documentation](/docs/images/guides/tagged_endpoints.png)
 

--- a/src/_specifications/openapi/v3.1/introduction/benefits.md
+++ b/src/_specifications/openapi/v3.1/introduction/benefits.md
@@ -87,6 +87,6 @@ Besides the ones mentioned above, here is an amazing and more exhaustive list of
 Now that you know what OpenAPI is, try it out with one of the following OpenAPI documents.
 
 * [Train Travel API](https://raw.githubusercontent.com/bump-sh-examples/train-travel-api/main/openapi.yaml)
-* [Bump API](https://developers.bump.sh/source.json)
+* [Bump API](https://developers.bump.sh/doc/workspace/source.json)
 
 Or why not learn to make your own, heading over to the next section: **[Understanding the Structure of OpenAPI](_specifications/openapi/v3.1/understanding-structure/basic-structure.md).**

--- a/src/_specifications/openapi/v3.2/advanced/callbacks-webhooks.md
+++ b/src/_specifications/openapi/v3.2/advanced/callbacks-webhooks.md
@@ -149,16 +149,16 @@ The key bits to notice here are:
 - The `requestBody` is the request you're going to send.
 - The `responses` property is a map of responses you want the client to return.
 
-These then don't need to be tied to paths. In fact, you can have an OpenAPI document which has no paths. This could be because you're splitting your documents up in interesting reusable ways with these webhooks being shared across multiple APIs, or because your API is entirely asynchronous. 
+These then don't need to be tied to paths. In fact, you can have an OpenAPI document which has no paths. This could be because you're splitting your documents up in interesting reusable ways with these webhooks being shared across multiple APIs, or because your API is entirely asynchronous.
 
-## Consider AsyncAPI 
+## Consider AsyncAPI
 
-If you are using a few webhooks in an API which is largely otherwise driven by request/response, OpenAPI will be just fine for you with callbacks and webhooks helping as needed. 
+If you are using a few webhooks in an API which is largely otherwise driven by request/response, OpenAPI will be just fine for you with callbacks and webhooks helping as needed.
 
 However if you are building an API that is entirely asynchronous, you are using technologies like WebSockets, or are working with any other event-driven API protocols, you should consider using [AsyncAPI](_guides/asyncapi/what-is-asyncapi.md) for describing those parts of the architecture.
 
 ## Examples
 
-There's a full example in either [Train Travel API](https://bump.sh/blog/modern-openapi-petstore-replacement), or [Bump.sh API](https://developers.bump.sh/operation/operation-webhookdocstructurechange): every structural change on API documentation generates a new request to this webhook.
+There's a full example in either [Train Travel API](https://bump.sh/blog/modern-openapi-petstore-replacement), or [Bump.sh API](https://developers.bump.sh/doc/workspace/operation/operation-webhookdocstructurechange): every structural change on API documentation generates a new request to this webhook.
 
 You can also find more information about documenting webhooks in [this blog post](https://bump.sh/blog/documenting-your-OpenAPI-webhooks).

--- a/src/_specifications/openapi/v3.2/introduction/benefits.md
+++ b/src/_specifications/openapi/v3.2/introduction/benefits.md
@@ -86,6 +86,6 @@ Besides the ones mentioned above, here is an amazing and more exhaustive list of
 Now that you know what OpenAPI is, try it out with one of the following OpenAPI documents.
 
 * [Train Travel API](https://raw.githubusercontent.com/bump-sh-examples/train-travel-api/main/openapi.yaml)
-* [Bump API](https://developers.bump.sh/source.json)
+* [Bump API](https://developers.bump.sh/doc/workspace/source.json)
 
 Or why not learn to make your own, heading over to the next section: **[Understanding the Structure of OpenAPI](_specifications/openapi/v3.2/understanding-structure/basic-structure.md).**


### PR DESCRIPTION
We'll move our Bump.sh documentation in hub, and transfer the custom domain from a Api to a Hub:

https://developers.bump.sh/ -> https://developers.bump.sh/doc/workspace/

Most of these changes will be ensured [via redirection](https://itducks.slack.com/archives/C08294CTDM3/p1780661912150059), but let's be as clean and consistent as possible.

(especially for https://developers.bump.sh/source.md that will be transferred valid for the Hub)

---

[following Slack message](https://itducks.slack.com/archives/C01QP6HK8JV/p1780581840817589?thread_ts=1780577001.842149&cid=C01QP6HK8JV)