### PR TITLE
Update per-user config doc to use the new $config expression

### DIFF
--- a/src/_help/mcp-servers/runtime-expressions.md
+++ b/src/_help/mcp-servers/runtime-expressions.md
@@ -127,15 +127,22 @@ Reference values tied to the user currently invoking the MCP server. Only availa
 | Expression | Source | Description |
 |---|---|---|
 | `$current_user.token` | `Authorization: Bearer ...` | OAuth token of the authenticated user |
-| `$current_user.<name>` | `Config-<Name>` header | Per-user config sent by the client |
 
 ```yaml
 headers:
   Authorization: "Bearer $current_user.token"
-  Config-Org-Id: "$current_user.org_id"
 ```
 
-For `$current_user.<name>`, matching is case-insensitive, and underscores in the expression map to dashes in the header. All of `$current_user.org_id`, `$current_user.ORG_ID` and `$current_user.Org-Id` resolve the same `Config-Org-Id` header.
+### Per-user config (`$config`)
+
+Reference per-user config values sent by the client through `Config-*` HTTP headers.
+
+```yaml
+headers:
+  Authorization: "Bearer $config.api_key"
+```
+
+Matching is case-insensitive, and underscores in the expression map to dashes in the header. All of `$config.org_id`, `$config.ORG_ID` and `$config.Org-Id` resolve the same `Config-Org-Id` header.
 
 If no matching header is sent by the client, the expression resolves to an empty string.
 

--- a/src/_help/mcp-servers/secrets-and-config.md
+++ b/src/_help/mcp-servers/secrets-and-config.md
@@ -33,7 +33,7 @@ flows:
     description: ...
     inputs: {}
     steps: []
-    security: $secrets.booking-api-key
+    security: $secrets.booking_api_key
 ```
 
 ### Storage and security
@@ -44,7 +44,7 @@ At runtime, secrets are decrypted in memory only for the duration of a workflow 
 
 ## Per-user config
 
-Per-user config lets each end-user supply their own values when they connect to your MCP server. The values are passed as HTTP headers prefixed with `Config-`, never stored on Bump.sh, and resolved in workflows through `$current_user.<name>`.
+Per-user config lets each end-user supply their own values when they interact with your MCP server. The values are passed as HTTP headers prefixed with `Config-`, never stored on Bump.sh, and resolved in workflows through `$config.<name>`.
 
 Typical use cases:
 
@@ -72,32 +72,32 @@ For instance, the following Cursor configuration sends two values, `api_key` and
 }
 ```
 
-> Headers without the `Config-` prefix are never forwarded to workflows. This protects sensitive headers (cookies, internal auth, ...) from being leaked through `$current_user.*`.
+> Headers without the `Config-` prefix are never forwarded to workflows. This protects sensitive headers (cookies, internal auth, ...) from being leaked through `$config.*`.
 {: .info}
 
 ### Using a config value in a workflow
 
-Reference the config value with `$current_user.<name>`:
+Reference the config value with `$config.<name>`:
 
 ```yaml
 steps:
   - id: list_projects
     request:
       method: GET
-      url: https://api.example.com/v1/orgs/$current_user.org_id/projects
+      url: https://api.example.com/v1/orgs/$config.org_id/projects
       headers:
-        Authorization: "Bearer $current_user.api_key"
+        Authorization: "Bearer $config.api_key"
 ```
 
 The matching between the runtime expression and the header name is case-insensitive, and underscores in the expression are mapped to dashes in the header. All these expressions resolve the same `Config-Api-Key` header:
 
 | Expression | Resolves to |
 |---|---|
-| `$current_user.api_key` | `Config-Api-Key` header |
-| `$current_user.API_KEY` | `Config-Api-Key` header |
-| `$current_user.Api-Key` | `Config-Api-Key` header |
+| `$config.api_key` | `Config-Api-Key` header |
+| `$config.API_KEY` | `Config-Api-Key` header |
+| `$config.Api-Key` | `Config-Api-Key` header |
 
-See [Runtime expressions](/help/mcp-servers/runtime-expressions/#current-user-current_user) for the full reference.
+See [Runtime expressions](/help/mcp-servers/runtime-expressions/#per-user-config-config) for the full reference.
 
 ### Storage and security
 

--- a/src/_help/mcp-servers/specification-support/flower-support.md
+++ b/src/_help/mcp-servers/specification-support/flower-support.md
@@ -205,6 +205,7 @@ Runtime expressions reference dynamic data during execution. They use a `$` pref
 | `$steps.step_id.outputs.key` | Output from a previous step. |
 | `$statusCode` | HTTP status code of the current response. |
 | `$secrets.name` | Secret value (never exposed in outputs). |
+| `$config.name` | Per-user config value, sent through `Config-*` headers. |
 
 For the complete reference (JMESPath queries, conditions, resolution order), see [Runtime expressions](/help/mcp-servers/runtime-expressions).
 

--- a/src/_help/mcp-servers/write-your-first-flower-workflow.md
+++ b/src/_help/mcp-servers/write-your-first-flower-workflow.md
@@ -94,7 +94,7 @@ flows:
           method: GET
           url: https://nominatim.openstreetmap.org/search
           headers:
-            Authorization: "Bearer $secrets.my-api-key"
+            Authorization: "Bearer $secrets.my_api_key"
           query:
             q: $inputs.city
             format: jsonv2
@@ -104,7 +104,7 @@ flows:
 ```
 
 A few things to notice:
--  `$secrets.my-api-key` injects a [secret](/help/mcp-servers/secrets/) stored on Bump.sh. 
+-  `$secrets.my_api_key` injects a [secret](/help/mcp-servers/secrets-and-config/) stored on Bump.sh. 
 - `$inputs.city` is a **runtime expression** that injects a value provided either by an AI agent or a human through its LLM. Expressions always start with `$`. See [Runtime expressions](/help/mcp-servers/runtime-expressions) for the full reference.
 - `query` maps to URL query parameters. The request above resolves to `GET /search?q=Paris&format=jsonv2` when `city` is `Paris`.
 - `outputs` extracts values from the response. `$response.body.0.lat` reads the `lat` property from the first element of the response array.
@@ -212,9 +212,9 @@ actions:
 
 ### Authenticate with protected APIs
 
-It's not the case in our example, but if the API you're calling requires authentication, create a [secret](/help/mcp-servers/secrets/) on Bump.sh to store the key securely. 
+It's not the case in our example, but if the API you're calling requires authentication, create a [secret](/help/mcp-servers/secrets-and-config/) on Bump.sh to store the key securely. 
 
-Reference it with the `$secrets.{name}` expression. You can also use `$currentUser.token` to directly retrieve the authenticated user's token.
+Reference it with the `$secrets.{name}` expression. You can also use `$current_user.token` to directly retrieve the authenticated user's token.
 
 For example, if the API expects the key in a request header, add it in the step `request.headers`:
 
@@ -227,7 +227,7 @@ flows:
           method: GET
           url: https://api.example.com/weather
           headers:
-            Authorization: "Bearer $secrets.my-api-key"
+            Authorization: "Bearer $secrets.my_api_key"
 ```
 
 > The secret is injected at runtime and never sent to the AI tool.
@@ -300,7 +300,7 @@ flows:
 ## Next steps
 
 - [Deploy this file](/help/mcp-servers/deploy-workflows/) to your MCP server.
-- Store API keys safely using [secrets](/help/mcp-servers/secrets/).
+- Store API keys safely using [secrets](/help/mcp-servers/secrets-and-config/).
 - Add more flows to the same file following the same pattern.
 - Learn how to do more complex data transformation and create condition trees using [Runtime expressions](/help/mcp-servers/runtime-expressions).
 - Read the full [Flower specification reference](/help/mcp-servers/specification-support/flower-support/) for all available properties and options.


### PR DESCRIPTION
Per-user Config-* headers are now resolved with $config.<name>, while $current_user only resolves the OAuth token. Also fix secret name examples that used dashes, which are not allowed.